### PR TITLE
Edge Shares - Changes for Ansible

### DIFF
--- a/cterasdk/edge/cache.py
+++ b/cterasdk/edge/cache.py
@@ -32,6 +32,7 @@ class Cache(BaseCommand):
     def pin(self, path):
         """
         Pin a folder
+
         :param str path: Directory path
         """
         directory_tree = self._fetch_pinning_config()
@@ -42,6 +43,7 @@ class Cache(BaseCommand):
     def pin_exclude(self, path):
         """
         Exclude a sub-folder from a pinned folder
+
         :param str path: Directory path
         """
         directory_tree = self._fetch_pinning_config()
@@ -52,6 +54,7 @@ class Cache(BaseCommand):
     def remove_pin(self, path):
         """
         Remove a pin from a previously pinned folder
+
         :param str path: Directory path
         """
         directory_tree = self._fetch_pinning_config()

--- a/cterasdk/edge/types.py
+++ b/cterasdk/edge/types.py
@@ -1,14 +1,80 @@
-from collections import namedtuple
+from . import enum
+from ..common import Object
+from ..exception import InputError
 
 
-ShareAccessControlEntry = namedtuple('ShareAccessControlEntry', ('type', 'name', 'perm'))
-ShareAccessControlEntry.__doc__ = 'Tuple holding the principal type, name and permission'
-ShareAccessControlEntry.type.__doc__ = 'The principal type'
-ShareAccessControlEntry.name.__doc__ = 'The name of the user or group'
-ShareAccessControlEntry.perm.__doc__ = 'The file access permission'
+class ShareAccessControlEntryBase():
+    _valid_principal_types = list({k: v for k, v in enum.PrincipalType.__dict__.items() if not k.startswith('_')}.values())
+
+    def __init__(self, principal_type, name):
+        if principal_type not in ShareAccessControlEntry._valid_principal_types:
+            raise InputError('Invalid principal type', principal_type, self._valid_principal_types)
+        self.principal_type = principal_type
+        self.name = name
+
+    def _create_principal2_object(self):
+        principal2 = Object()
+        if self.principal_type == enum.PrincipalType.LU:
+            principal2._classname = enum.PrincipalType.LU  # pylint: disable=protected-access
+            principal2.ref = "#config#auth#users#" + self.name
+        elif self.principal_type == enum.PrincipalType.LG:
+            principal2._classname = enum.PrincipalType.LG  # pylint: disable=protected-access
+            principal2.ref = "#config#auth#groups#" + self.name
+        elif self.principal_type == enum.PrincipalType.DU:
+            principal2._classname = enum.PrincipalType.DU  # pylint: disable=protected-access
+            principal2.name = self.name
+        elif self.principal_type == enum.PrincipalType.DG:
+            principal2._classname = enum.PrincipalType.DG  # pylint: disable=protected-access
+            principal2.name = self.name
+        return principal2
 
 
-RemoveShareAccessControlEntry = namedtuple('RemoveShareAccessControlEntry', ('type', 'name'))
-RemoveShareAccessControlEntry.__doc__ = 'Tuple holding the principal type and name'
-RemoveShareAccessControlEntry.type.__doc__ = 'The principal type'
-RemoveShareAccessControlEntry.name.__doc__ = 'The name of the user or group'
+class ShareAccessControlEntry(ShareAccessControlEntryBase):
+    """
+    Share access control entry for filer shares
+
+    :ivar cterasdk.edge.enum.PrincipalType principal_type: Principal type of the ACL
+    :ivar str name: The name of the user or group
+    :ivar cterasdk.edge.enum.FileAccessMode perm: The file access permission
+    """
+
+    _valid_permissions = list({k: v for k, v in enum.FileAccessMode.__dict__.items() if not k.startswith('_')}.values())
+
+    def __init__(self, principal_type, name, perm):
+        super().__init__(principal_type=principal_type, name=name)
+        if perm not in ShareAccessControlEntry._valid_permissions:
+            raise InputError('Invalid permissions', perm, ShareAccessControlEntry._valid_permissions)
+        self.perm = perm
+
+    def to_server_object(self):
+        ace = Object()
+        ace._classname = "ShareACLRule"  # pylint: disable=protected-access
+        ace.principal2 = self._create_principal2_object()
+        ace.permissions = self._create_permissions_object()
+        return ace
+
+    def _create_permissions_object(self):
+        permissions = Object()
+        permissions._classname = "FileAccessPermissions"  # pylint: disable=protected-access
+        permissions.allowedFileAccess = self.perm
+        return permissions
+
+    @staticmethod
+    def from_server_object(server_object):
+        principal_type = server_object.principal2._classname  # pylint: disable=protected-access
+        if principal_type in [enum.PrincipalType.LU, enum.PrincipalType.LG]:
+            name = server_object.principal2.ref
+            name = name[name.rfind('#') + 1:]
+        else:
+            name = server_object.principal2.name
+        perm = server_object.permissions.allowedFileAccess
+        return ShareAccessControlEntry(principal_type, name, perm)
+
+
+class RemoveShareAccessControlEntry(ShareAccessControlEntryBase):
+    """
+    Object holding share access control principal type and name
+
+    :ivar cterasdk.edge.enum.PrincipalType principal_type: Principal type of the ACL
+    :ivar str name: The name of the user or group
+    """

--- a/docs/source/user_guides/Gateway/Gateway.rst
+++ b/docs/source/user_guides/Gateway/Gateway.rst
@@ -569,14 +569,6 @@ Caching
 
    filer.cache.force_eviction()
 
-.. automethod:: cterasdk.edge.cache.Cache.get_pinned_folders
-   :noindex:
-
-.. code-block:: python
-
-   """ Get pinned folders """
-   filer.cache.get_pinned_folders()
-
 .. automethod:: cterasdk.edge.cache.Cache.pin
    :noindex:
 

--- a/docs/source/user_guides/Gateway/Gateway.rst
+++ b/docs/source/user_guides/Gateway/Gateway.rst
@@ -297,10 +297,10 @@ Shares
    - NA: No Access
    """
 
-   everyone = gateway_types.ShareAccessControlEntry('LG', 'Everyone', 'RO')
-   local_admin = gateway_types.ShareAccessControlEntry('LU', 'admin', 'RW')
-   domain_admins = gateway_types.ShareAccessControlEntry('DG', 'CTERA\Domain Admins', 'RO')
-   bruce_wayne = gateway_types.ShareAccessControlEntry('DU', 'bruce.wayne@ctera.com', 'RW')
+   everyone = gateway_types.ShareAccessControlEntry(gateway_enum.PrincipalType.LG, 'Everyone', gateway_enum.FileAccessMode.RO)
+   local_admin = gateway_types.ShareAccessControlEntry(gateway_enum.PrincipalType.LU, 'admin', gateway_enum.FileAccessMode.RW)
+   domain_admins = gateway_types.ShareAccessControlEntry(gateway_enum.PrincipalType.DG, 'CTERA\Domain Admins', gateway_enum.FileAccessMode.RO)
+   bruce_wayne = gateway_types.ShareAccessControlEntry(gateway_enum.PrincipalType.DU, 'bruce.wayne@ctera.com', gateway_enum.FileAccessMode.RW)
 
    filer.shared.add('Accounting', 'cloud/users/Service Account/Accounting', acl = [ \
        everyone, local_admin, domain_admins, bruce_wayne \
@@ -308,9 +308,9 @@ Shares
 
    """Create an 'Only Authenticated Users' cloud share called 'FTP' and enable FTP access to everyone"""
 
-   everyone = gateway_types.ShareAccessControlEntry('LG', 'Everyone', 'RW')
+   everyone = gateway_types.ShareAccessControlEntry(gateway_enum.PrincipalType.LG, 'Everyone', gateway_enum.FileAccessMode.RW)
 
-   filer.shared.add('FTP', 'cloud/users/Service Account/FTP', acl = [everyone], exportToFTP = True)
+   filer.shared.add('FTP', 'cloud/users/Service Account/FTP', acl = [everyone], export_to_ftp = True)
 
 .. automethod:: cterasdk.edge.shares.Shares.add_acl
    :noindex:
@@ -319,8 +319,8 @@ Shares
 
    """Add two access control entries to the 'Accounting' share"""
 
-   domain_group = gateway_types.ShareAccessControlEntry('DG', 'CTERA\leadership', 'RW')
-   domain_user = gateway_types.ShareAccessControlEntry('DU', 'clark.kent@ctera.com', 'RO')
+   domain_group = gateway_types.ShareAccessControlEntry(gateway_enum.PrincipalType.DG, 'CTERA\leadership', gateway_enum.FileAccessMode.RW)
+   domain_user = gateway_types.ShareAccessControlEntry(gateway_enum.PrincipalType.DU, 'clark.kent@ctera.com', gateway_enum.FileAccessMode.RO)
 
    filer.shares.add_acl('Accounting', [domain_group, domain_user])
 
@@ -331,8 +331,8 @@ Shares
 
    """Set the access control entries of the 'Accounting' share"""
 
-   domain_group = gateway_types.ShareAccessControlEntry('DG', 'CTERA\leadership', 'RW')
-   domain_user = gateway_types.ShareAccessControlEntry('DU', 'clark.kent@ctera.com', 'RO')
+   domain_group = gateway_types.ShareAccessControlEntry(gateway_enum.PrincipalType.DG, 'CTERA\leadership', gateway_enum.FileAccessMode.RW)
+   domain_user = gateway_types.ShareAccessControlEntry(gateway_enum.PrincipalType.DU, 'clark.kent@ctera.com', gateway_enum.FileAccessMode.RO)
 
    filer.shares.set_acl('Accounting', [domain_group, domain_user])
 
@@ -343,8 +343,8 @@ Shares
 
    """Remove access control entries from the 'Accounting' share"""
 
-   domain_group = gateway_types.RemoveShareAccessControlEntry('DG', 'CTERA\leadership')
-   domain_user = gateway_types.RemoveShareAccessControlEntry('DU', 'clark.kent@ctera.com')
+   domain_group = gateway_types.RemoveShareAccessControlEntry(gateway_enum.PrincipalType.DG, 'CTERA\leadership')
+   domain_user = gateway_types.RemoveShareAccessControlEntry(gateway_enum.PrincipalType.DU, 'clark.kent@ctera.com')
 
    filer.shares.remove_acl('Accounting', [domain_group, domain_user])
 
@@ -362,37 +362,31 @@ Shares
 
    filer.shares.block_files('Accounting', ['exe', 'cmd', 'bat'])
 
+.. automethod:: cterasdk.edge.shares.Shares.modify
+   :noindex:
+
+.. code-block:: python
+
+   """ Disable all file-access protocols on all shares """
+   shares = filer.shares.get() # obtain a list of all shares
+
+   for share in shares:
+      filer.share.modify(
+         share.name,
+         export_to_afp=False,       # Apple File Sharing
+         export_to_ftp=False,       # FTP
+         export_to_nfs=False,       # NFS
+         export_to_pc_agent=False,  # CTERA Agent
+         export_to_rsync=False,     # rsync
+         indexed=False              # Search
+      )
+
 .. automethod:: cterasdk.edge.shares.Shares.delete
    :noindex:
 
 .. code-block:: python
 
    filer.shares.delete('Accounting')
-
-Code Snippets
-^^^^^^^^^^^^^
-
-Disable all file-access protocols on all shares
-
-.. code-block:: python
-
-   shares = filer.get('/config/fileservices/share') # obtain a list of all shares
-
-   for share in shares:
-
-       share.exportToAFP = False            # Apple File Sharing
-
-       share.exportToFTP = False            # FTP
-
-       share.exportToNFS = False            # NFS
-
-       share.exportToRSync = False          # rsync
-
-       share.exportToPCAgent = False        # CTERA Agent
-
-       share.indexed = False                # Search
-
-       filer.put('/config/fileservices/share/' + share.name, share) # apply changes
 
 Users
 =====

--- a/samples/gateway_sample.py
+++ b/samples/gateway_sample.py
@@ -1,6 +1,6 @@
 import logging
 
-from cterasdk import Gateway, gateway_enum, config, CTERAException
+from cterasdk import Gateway, gateway_enum, config, CTERAException, gateway_types
 
 from sample_base import CTERASDKSampleBase
 
@@ -109,8 +109,33 @@ class GatewaySample(CTERASDKSampleBase):
         self._device.shares.add(
             directory_name,
             '/'.join([self._volume_name, directory_path]),
-            acl=[('LG', 'Everyone', 'RW'), ('LG', 'Administrators', 'RO')],
+            acl=[
+                gateway_types.ShareAccessControlEntry(
+                    principal_type=gateway_enum.PrincipalType.LG,
+                    name='Everyone',
+                    perm=gateway_enum.FileAccessMode.RW
+                )
+            ],
             access=gateway_enum.Acl.OnlyAuthenticatedUsers
+        )
+        self._device.shares.add_acl(
+            directory_name,
+            [
+                gateway_types.ShareAccessControlEntry(
+                    principal_type=gateway_enum.PrincipalType.LG,
+                    name='Administrators',
+                    perm=gateway_enum.FileAccessMode.RO
+                )
+            ]
+        )
+        self._device.shares.remove_acl(
+            directory_name,
+            acl=[
+                gateway_types.RemoveShareAccessControlEntry(
+                    principal_type=gateway_enum.PrincipalType.LG,
+                    name='Everyone'
+                )
+            ]
         )
         print("New share was created successfully")
 


### PR DESCRIPTION
Types
-----
Convert ShareAccessControlEntry and RemoveShareAccessControlEntry to classes
Add a base for ShareAccessControlEntry and RemoveShareAccessControlEntry
Validate values at init time - enum values and not keys
ShareAccessControlEntry - Implement to and from server object

Shares
------
Add modify API
Use the new class and its methods
Rename parameters to lower_case_with_underscores
Fix remove_acl
Update docstrings

Docs
----
Shares section - Replace code snippet with usage of modify

GW Sample
---------
Update to use the revised APIs
Add calls to add_acl and remove_acl

Update UT