### PR TITLE
Allow passing session id instead of logging in

### DIFF
--- a/cterasdk/client/cteraclient.py
+++ b/cterasdk/client/cteraclient.py
@@ -9,8 +9,8 @@ from .. import config
 
 class CTERAClient:
 
-    def __init__(self):
-        self.http_client = HTTPClient()
+    def __init__(self, session_id_key):
+        self.http_client = HTTPClient(session_id_key)
 
     def get(self, baseurl, path, params=None):
         function = Command(HTTPClient.get, self.http_client, geturi(baseurl, path), params if params else {})
@@ -64,6 +64,12 @@ class CTERAClient:
         obj.param = param
         function = Command(HTTPClient.post, self.http_client, geturi(baseurl, path), ContentType.textplain, toxmlstr(obj))
         return self._execute(function)
+
+    def get_session_id(self):
+        return self.http_client.get_session_id()
+
+    def set_session_id(self, session_id):
+        return self.http_client.set_session_id(session_id)
 
     @staticmethod
     def fromxmlstr(request, response):

--- a/cterasdk/client/http.py
+++ b/cterasdk/client/http.py
@@ -77,12 +77,13 @@ class ContentType:
 
 
 class HttpClientBase():
-    def __init__(self):
+    def __init__(self, session_id_key):
         self.timeout = config.http['timeout']
         self.retries = config.http['retries']
         self.ssl_error_handling = config.http['ssl']
         self.session = requests.Session()
         self.session.verify = self.ssl_error_handling != 'Trust'
+        self._session_id_key = session_id_key
 
     def dispatch(self, ctera_request):
         attempt = 0
@@ -135,6 +136,12 @@ class HttpClientBase():
 
     def trust(self, _host, _port):
         self.session.verify = False  # CertificateServices.save_cert_from_server(host, port)
+
+    def get_session_id(self):
+        return self.session.cookies.get(self._session_id_key)
+
+    def set_session_id(self, session_id):
+        self.session.cookies.set(self._session_id_key, session_id)
 
 
 class HttpClientRequest():

--- a/cterasdk/core/login.py
+++ b/cterasdk/core/login.py
@@ -1,7 +1,6 @@
 import logging
 
 from .base_command import BaseCommand
-from . import session
 
 
 class Login(BaseCommand):
@@ -17,17 +16,11 @@ class Login(BaseCommand):
         :param str password: User password
         """
         self._portal.form_data('/login', {'j_username': username, 'j_password': password})
-
         logging.getLogger().info("User logged in. %s", {'host': self._portal.host(), 'user': username})
-
-        session.activate(self._portal)
 
     def logout(self):
         """
         Log out of the portal
         """
         self._portal.form_data('/logout', {})
-
         logging.getLogger().info("User logged out. %s", {'host': self._portal.host()})
-
-        session.terminate(self._portal)

--- a/cterasdk/core/session.py
+++ b/cterasdk/core/session.py
@@ -1,94 +1,23 @@
-import logging
-
-from ..common import Object
+from ..lib.session_base import SessionBase, SessionUser
 from .enum import Context
 
 
-def inactive_session(Portal):
-    session = Session(Portal.host(), Portal.context)
-    Portal.register_session(session)
-
-
-def activate(Portal):
-    session = Portal.session()
-    session.initialize()
-
-    tenant = obtain_tenant(Portal)
-    user, role = obtain_user(Portal)
-    session.activate(tenant, user, role)
-
-
-def terminate(Portal):
-    inactive_session(Portal)
-
-
-def obtain_user(CTERAHost):
-    logging.getLogger().debug('Obtaining current user session.')
-
-    current_session = CTERAHost.get('/currentSession')
-
-    logging.getLogger().debug('Obtained current user session.')
-
-    return (current_session.username, current_session.role)
-
-
-def obtain_tenant(CTERAHost):
-    logging.getLogger().debug('Obtaining current tenant.')
-
-    current_tenant = CTERAHost.get('/currentPortal')
-
-    logging.getLogger().debug('Obtained current tenant. %s', {'name': current_tenant})
-
-    return current_tenant
-
-
-class SessionStatus:
-    Initializing = 'Initializing'
-    Inactive = 'Inactive'
-    Active = 'Active'
-
-
-class Session(Object):
+class Session(SessionBase):
 
     def __init__(self, host, context):
-        self.host = host
+        super().__init__(host)
         self.context = context
-        self.status = SessionStatus.Inactive
-        self.current_tenant = None
-        self.user = None
 
-    def initialize(self):
-        self.status = SessionStatus.Initializing
+    def _do_start_local_session(self, ctera_host):
+        tenant = ctera_host.get('/currentPortal') or 'Administration'
+        current_session = ctera_host.get('/currentSession')
+        self.user = SessionUser(current_session.username, tenant=tenant, role=current_session.role)
 
-    def activate(self, tenant, user, role):
-        self.update_tenant(tenant)
-
-        self.user = Object()
-        self.user.name = user
-        self.user.role = role
-
-        self.status = SessionStatus.Active
+    def _do_terminate(self):
+        pass
 
     def update_tenant(self, current_tenant):
-        if not current_tenant:
-            self.current_tenant = 'Administration'
-        else:
-            self.current_tenant = current_tenant
-
-    def user_name(self):
-        return self.user.name
+        self.user.tenant = current_tenant or 'Administration'
 
     def global_admin(self):
         return self.context == Context.admin
-
-    def tenant(self):
-        return self.current_tenant
-
-    def initializing(self):
-        return self.status == SessionStatus.Initializing
-
-    def authenticated(self):
-        return self.status == SessionStatus.Active
-
-    def whoami(self):
-        print(self)

--- a/cterasdk/edge/login.py
+++ b/cterasdk/edge/login.py
@@ -1,6 +1,5 @@
 import logging
 
-from . import session
 from ..exception import CTERAException
 from .base_command import BaseCommand
 
@@ -12,7 +11,6 @@ class Login(BaseCommand):
         try:
             self._gateway.form_data('/login', {'username': username, 'password': password})
             logging.getLogger().info("User logged in. %s", {'host': host, 'user': username})
-            session.start_local_session(self._gateway, host, username)
         except CTERAException as error:
             logging.getLogger().error("Login failed. %s", {'host': host, 'user': username})
             raise error
@@ -20,7 +18,6 @@ class Login(BaseCommand):
     def logout(self):
         try:
             self._gateway.form_data('/logout', {'foo': 'bar'})
-            session.terminate(self._gateway)
             logging.getLogger().info("User logged out. %s", {'host': self._gateway.host()})
         except CTERAException as error:
             raise error

--- a/cterasdk/lib/session_base.py
+++ b/cterasdk/lib/session_base.py
@@ -1,0 +1,50 @@
+from ..common import Object
+
+
+class SessionStatus:
+    Initializing = 'Initializing'
+    Inactive = 'Inactive'
+    Active = 'Active'
+
+
+class SessionUser(Object):
+    def __init__(self, name, tenant=None, role=None):
+        self.name = name
+        self.tenant = tenant
+        self.role = role
+
+
+class SessionBase(Object):
+
+    def __init__(self, host):
+        self.host = host
+        self.status = SessionStatus.Inactive
+        self.user = None
+
+    def start_local_session(self, ctera_host):
+        self.status = SessionStatus.Initializing
+        self._do_start_local_session(ctera_host)
+        self.status = SessionStatus.Active
+
+    def _do_start_local_session(self, ctera_host):
+        raise NotImplementedError("Implementing class must implement the _do_start_local_session method")
+
+    def terminate(self):
+        self._do_terminate()
+        self.status = SessionStatus.Inactive
+        self.user = None
+
+    def _do_terminate(self):
+        raise NotImplementedError("Implementing class must implement the _do_terminate method")
+
+    def tenant(self):
+        return self.user.tenant if self.user else None
+
+    def initializing(self):
+        return self.status == SessionStatus.Initializing
+
+    def authenticated(self):
+        return self.status == SessionStatus.Active
+
+    def whoami(self):
+        print(self)

--- a/cterasdk/object/Agent.py
+++ b/cterasdk/object/Agent.py
@@ -17,10 +17,11 @@ class Agent(CTERAHost):
         """
         super().__init__(host, port, https)
         self._remote_access = False
+        self._session = session.Session(self.host())
         if Portal is not None:
             self._Portal = Portal
             self._ctera_client = Portal._ctera_client
-            session.start_remote_session(self, Portal)
+            self._session.start_remote_session(self._Portal.session())
 
     @property
     def base_api_url(self):
@@ -29,6 +30,10 @@ class Agent(CTERAHost):
     @property
     def _login_object(self):
         raise NotImplementedError("Currently login is not supported for Agent")
+
+    @property
+    def _session_id_key(self):
+        return ''
 
     def _is_authenticated(self, function, *args, **kwargs):
         return True

--- a/cterasdk/object/Portal.py
+++ b/cterasdk/object/Portal.py
@@ -39,7 +39,7 @@ class Portal(CTERAHost):
         :param bool https: Set to True to require HTTPS
         """
         super().__init__(host, port, https)
-        session.inactive_session(self)
+        self._session = session.Session(self.host(), self.context)
         self.users = users.Users(self)
         self.reports = reports.Reports(self)
         self.devices = devices.Devices(self)
@@ -61,6 +61,10 @@ class Portal(CTERAHost):
     @property
     def base_file_url(self):
         return self.baseurl()
+
+    @property
+    def _session_id_key(self):
+        return 'JSESSIONID'
 
     @property
     def context(self):

--- a/docs/source/api/cterasdk.lib.rst
+++ b/docs/source/api/cterasdk.lib.rst
@@ -18,6 +18,7 @@ Submodules
    cterasdk.lib.iterator
    cterasdk.lib.platform
    cterasdk.lib.registry
+   cterasdk.lib.session_base
    cterasdk.lib.tempfile
    cterasdk.lib.tracker
    cterasdk.lib.version

--- a/docs/source/api/cterasdk.lib.session_base.rst
+++ b/docs/source/api/cterasdk.lib.session_base.rst
@@ -1,0 +1,7 @@
+cterasdk.lib.session_base module
+================================
+
+.. automodule:: cterasdk.lib.session_base
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/tests/ut/test_core_login.py
+++ b/tests/ut/test_core_login.py
@@ -35,12 +35,6 @@ class TestCoreLogin(base_core.BaseCoreTest):
         self._global_admin.get = mock.MagicMock(side_effect=TestCoreLogin._obtain_session_info)
         login.Login(self._global_admin).login(self._username, self._password)
         self._global_admin.form_data.assert_called_once_with('/login', {'j_username': self._username, 'j_password': self._password})
-        self._global_admin.get.assert_has_calls(
-            [
-                mock.call('/currentPortal'),
-                mock.call('/currentSession')
-            ]
-        )
 
     def test_logout_success(self):
         self._init_global_admin()

--- a/tests/ut/test_core_remote.py
+++ b/tests/ut/test_core_remote.py
@@ -50,7 +50,8 @@ class TestCoreRemote(base_core.BaseCoreTest):
         self.assertIsInstance(portal_device, instance_type)
 
     def _activate_portal_session(self):
-        self._global_admin.session().activate(self._device_portal, self._user_name, self._user_role)
+        self._global_admin.get = mock.MagicMock(side_effect=['team-portal-name', TestCoreRemote._create_current_session_object()])
+        self._global_admin.session().start_local_session(self._global_admin)
 
     @staticmethod
     def _create_device_param(name, portal, device_type):
@@ -59,3 +60,10 @@ class TestCoreRemote(base_core.BaseCoreTest):
         param.portal = portal
         param.deviceType = device_type
         return param
+
+    @staticmethod
+    def _create_current_session_object():
+        session = Object()
+        session.username = 'admin'
+        session.role = 'admin'
+        return session


### PR DESCRIPTION
HttpClientBase, CTERAClient and CTERAHost - Add APIs for getting and setting session id
CTERAHost add property for session is key, implement in subclasses and pass to HttpClientBase through CTERAClient
Move calls to Activate and Terminate session from login object to CTERAHost
Activate local session also when setting session id
Refactor Edge and Core Session classes to use a common parent class and remove helper methods
Update UT
Update Docs