### PR TITLE
Core Users - Allow the caller to set password expiration on user creation

### DIFF
--- a/cterasdk/common/__init__.py
+++ b/cterasdk/common/__init__.py
@@ -1,2 +1,3 @@
 from .item import Item  # noqa: E402, F401
 from .object import Object  # noqa: E402, F401
+from .datetime_utils import DateTimeUtils  # noqa: E402, F401

--- a/cterasdk/common/datetime_utils.py
+++ b/cterasdk/common/datetime_utils.py
@@ -1,0 +1,21 @@
+import datetime
+
+
+class DateTimeUtils():
+    @staticmethod
+    def get_expiration_date(expiration):
+        """
+        Get a datetime.date representation of the expiration date
+
+        :param variable,optional expiration:
+            The expiration value.
+            Pass datetime.date for a specific date, integer for days from now, or True for immediate (yesterday)
+        :return datetime.date: datetime.date representation of the expiration date
+        """
+        if isinstance(expiration, bool):
+            expiration_date = datetime.date.today() - datetime.timedelta(days=1)
+        elif isinstance(expiration, int):
+            expiration_date = datetime.date.today() + datetime.timedelta(days=expiration)
+        elif isinstance(expiration, datetime.date):
+            expiration_date = expiration
+        return expiration_date

--- a/cterasdk/core/users.py
+++ b/cterasdk/core/users.py
@@ -2,7 +2,7 @@ import logging
 
 from .base_command import BaseCommand
 from ..exception import CTERAException
-from ..common import Object
+from ..common import Object, DateTimeUtils
 from . import query
 from . import union
 
@@ -63,7 +63,7 @@ class Users(BaseCommand):
         param = query.QueryParamBuilder().include(include).build()
         return query.iterator(self._portal, '/domains/' + domain + '/adUsers', param)
 
-    def add(self, name, email, first_name, last_name, password, role, company=None, comment=None):
+    def add(self, name, email, first_name, last_name, password, role, company=None, comment=None, password_change=False):
         """
         Add a portal user
 
@@ -75,6 +75,9 @@ class Users(BaseCommand):
         :param cterasdk.core.enum.Role role: User role of the new user
         :param str,optional company: The name of the company of the new user, defaults to None
         :param str,optional comment: Additional comment for the new user, defaults to None
+        :param variable,optional password_change:
+            Require the user to change the password on the first login.
+            Pass datetime.date for a specific date, integer for days from creation, or True for immediate , defaults to False
         """
         param = Object()
         param._classname = "PortalUser"  # pylint: disable=protected-access
@@ -86,6 +89,8 @@ class Users(BaseCommand):
         param.role = role
         param.company = company
         param.comment = comment
+        if password_change:
+            param.requirePasswordChangeOn = DateTimeUtils.get_expiration_date(password_change).strftime('%Y-%m-%d')
 
         logging.getLogger().info('Creating user. %s', {'user': name})
 

--- a/docs/source/api/cterasdk.common.datetime_utils.rst
+++ b/docs/source/api/cterasdk.common.datetime_utils.rst
@@ -1,0 +1,7 @@
+cterasdk.common.datetime_utils module
+======================================
+
+.. automodule:: cterasdk.common.datetime_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api/cterasdk.common.rst
+++ b/docs/source/api/cterasdk.common.rst
@@ -11,6 +11,6 @@ Submodules
 
 .. toctree::
 
+   cterasdk.common.datetime_utils
    cterasdk.common.item
    cterasdk.common.object
-


### PR DESCRIPTION
Add a new parameter to users.add. The new parameter can be of three
types:
1. Boolean True - Immediate
2. Integer - days from creation
3. datetime.date - for specific expiration date