### PR TITLE
Hide secrets from logs

### DIFF
--- a/cterasdk/client/host.py
+++ b/cterasdk/client/host.py
@@ -155,13 +155,13 @@ class CTERAHost(NetworkHost):  # pylint: disable=too-many-public-methods
     def put(self, path, value, use_file_url=False):
         """ Update a schema object or attribute. """
         response = self._ctera_client.put(self.base_file_url if use_file_url else self.base_api_url, path, value)
-        logging.getLogger().debug('Configuration changed. %s', {'url': path, 'value': tojsonstr(value, False, True)})
+        logging.getLogger().debug('Configuration changed. %s', {'url': path, 'value': tojsonstr(value, pretty_print=False)})
         return response
 
     @authenticated
     def post(self, path, value, use_file_url=False):
         response = self._ctera_client.post(self.base_file_url if use_file_url else self.base_api_url, path, value)
-        logging.getLogger().debug('Added. %s', {'url': path, 'value': tojsonstr(value, False, True)})
+        logging.getLogger().debug('Added. %s', {'url': path, 'value': tojsonstr(value, pretty_print=False)})
         return response
 
     def form_data(self, path, form_data, use_file_url=False):
@@ -170,14 +170,14 @@ class CTERAHost(NetworkHost):  # pylint: disable=too-many-public-methods
     @authenticated
     def db(self, path, name, param, use_file_url=False):
         response = self._ctera_client.db(self.base_file_url if use_file_url else self.base_api_url, path, name, param)
-        logging.getLogger().debug('Database method executed. %s', {'url': path, 'name': name, 'param': tojsonstr(param, False, True)})
+        logging.getLogger().debug('Database method executed. %s', {'url': path, 'name': name, 'param': tojsonstr(param, pretty_print=False)})
         return response
 
     @authenticated
     def execute(self, path, name, param=None, use_file_url=False):
         """ Execute a schema object method. """
         response = self._ctera_client.execute(self.base_file_url if use_file_url else self.base_api_url, path, name, param)
-        logging.getLogger().debug('User-defined method executed. %s', {'url': path, 'name': name, 'param': tojsonstr(param, False, True)})
+        logging.getLogger().debug('User-defined method executed. %s', {'url': path, 'name': name, 'param': tojsonstr(param, pretty_print=False)})
         return response
 
     @authenticated

--- a/cterasdk/client/host.py
+++ b/cterasdk/client/host.py
@@ -139,7 +139,7 @@ class CTERAHost(NetworkHost):  # pylint: disable=too-many-public-methods
     @authenticated
     def show(self, path, use_file_url=False):
         """ Print a schema object as a JSON string. """
-        print(tojsonstr(self.get(path, params={}, use_file_url=use_file_url)))
+        print(tojsonstr(self.get(path, params={}, use_file_url=use_file_url), no_log=False))
 
     @authenticated
     def get_multi(self, path, paths, use_file_url=False):
@@ -149,7 +149,7 @@ class CTERAHost(NetworkHost):  # pylint: disable=too-many-public-methods
     @authenticated
     def show_multi(self, path, paths, use_file_url=False):
         """ Print one or more schema objects as a JSON string. """
-        print(tojsonstr(self.get_multi(path, paths, use_file_url=use_file_url)))
+        print(tojsonstr(self.get_multi(path, paths, use_file_url=use_file_url), no_log=False))
 
     @authenticated
     def put(self, path, value, use_file_url=False):

--- a/cterasdk/client/host.py
+++ b/cterasdk/client/host.py
@@ -170,14 +170,20 @@ class CTERAHost(NetworkHost):  # pylint: disable=too-many-public-methods
     @authenticated
     def db(self, path, name, param, use_file_url=False):
         response = self._ctera_client.db(self.base_file_url if use_file_url else self.base_api_url, path, name, param)
-        logging.getLogger().debug('Database method executed. %s', {'url': path, 'name': name, 'param': tojsonstr(param, pretty_print=False)})
+        logging.getLogger().debug(
+            'Database method executed. %s',
+            {'url': path, 'name': name, 'param': tojsonstr(param, pretty_print=False)}
+        )
         return response
 
     @authenticated
     def execute(self, path, name, param=None, use_file_url=False):
         """ Execute a schema object method. """
         response = self._ctera_client.execute(self.base_file_url if use_file_url else self.base_api_url, path, name, param)
-        logging.getLogger().debug('User-defined method executed. %s', {'url': path, 'name': name, 'param': tojsonstr(param, pretty_print=False)})
+        logging.getLogger().debug(
+            'User-defined method executed. %s',
+            {'url': path, 'name': name, 'param': tojsonstr(param, pretty_print=False)}
+        )
         return response
 
     @authenticated

--- a/cterasdk/client/host.py
+++ b/cterasdk/client/host.py
@@ -155,13 +155,13 @@ class CTERAHost(NetworkHost):  # pylint: disable=too-many-public-methods
     def put(self, path, value, use_file_url=False):
         """ Update a schema object or attribute. """
         response = self._ctera_client.put(self.base_file_url if use_file_url else self.base_api_url, path, value)
-        logging.getLogger().debug('Configuration changed. %s', {'url': path, 'value': str(value)})
+        logging.getLogger().debug('Configuration changed. %s', {'url': path, 'value': tojsonstr(value, False, True)})
         return response
 
     @authenticated
     def post(self, path, value, use_file_url=False):
         response = self._ctera_client.post(self.base_file_url if use_file_url else self.base_api_url, path, value)
-        logging.getLogger().debug('Added. %s', {'url': path, 'value': str(value)})
+        logging.getLogger().debug('Added. %s', {'url': path, 'value': tojsonstr(value, False, True)})
         return response
 
     def form_data(self, path, form_data, use_file_url=False):
@@ -170,14 +170,14 @@ class CTERAHost(NetworkHost):  # pylint: disable=too-many-public-methods
     @authenticated
     def db(self, path, name, param, use_file_url=False):
         response = self._ctera_client.db(self.base_file_url if use_file_url else self.base_api_url, path, name, param)
-        logging.getLogger().debug('Database method executed. %s', {'url': path, 'name': name, 'param': str(param)})
+        logging.getLogger().debug('Database method executed. %s', {'url': path, 'name': name, 'param': tojsonstr(param, False, True)})
         return response
 
     @authenticated
     def execute(self, path, name, param=None, use_file_url=False):
         """ Execute a schema object method. """
         response = self._ctera_client.execute(self.base_file_url if use_file_url else self.base_api_url, path, name, param)
-        logging.getLogger().debug('User-defined method executed. %s', {'url': path, 'name': name, 'param': str(param)})
+        logging.getLogger().debug('User-defined method executed. %s', {'url': path, 'name': name, 'param': tojsonstr(param, False, True)})
         return response
 
     @authenticated

--- a/cterasdk/common/object.py
+++ b/cterasdk/common/object.py
@@ -1,27 +1,6 @@
-# pylint: disable=too-many-instance-attributes
-import copy
 import json
 
 
-class Object:
-    _sdk_hidden = [
-        'password',
-        'awsSecretKey',
-        'sharedSecret',
-        'passPhraseSalt',
-        'encPassphrase',
-        'encryptedFolderKey',
-        'oldPassword',
-        'newPassword',
-        'secretkey',
-        'activationCode'
-    ]
-
+class Object:  # pylint: disable=too-many-instance-attributes
     def __str__(self):
-        def to_protected_dict(o):
-            ret = copy.deepcopy(o.__dict__)
-            for key in o._sdk_hidden:  # pylint: disable=protected-access
-                if key in ret:
-                    ret[key] = '*** The Value is Hidden by the SDK ***'
-            return ret
-        return json.dumps(self, default=to_protected_dict, indent=5)
+        return json.dumps(self, default=lambda o: o.__dict__, indent=5)

--- a/cterasdk/convert/format.py
+++ b/cterasdk/convert/format.py
@@ -1,5 +1,6 @@
 import queue
 import json
+import copy
 from xml.etree.ElementTree import Element, SubElement, tostring
 from xml.dom import minidom
 
@@ -7,28 +8,52 @@ from cterasdk.common import Item, Object
 from cterasdk.convert.xml_types import XMLTypes
 
 
-def tojsonstr(obj, pretty_print=True):
+_sdk_hidden = [
+    'password',
+    'awsSecretKey',
+    'sharedSecret',
+    'passPhraseSalt',
+    'encPassphrase',
+    'encryptedFolderKey',
+    'oldPassword',
+    'newPassword',
+    'secretkey',
+    'activationCode'
+]
+
+
+def _to_protected_dict(o):
+    ret = copy.deepcopy(o.__dict__)
+    for key in _sdk_hidden:
+        if key in ret:
+            ret[key] = '*** The Value is Hidden by the SDK ***'
+    return ret
+
+
+def tojsonstr(obj, pretty_print=True, no_log=False):
     """
     Convert a Python object to a JSON string.
 
-   :param object obj: the Python object
-   :param bool pretty_print: Whether to format the JSON string, defaults to ``True``
-   :return: JSON string of the object
-   :rtype: str
+    :param object obj: the Python object
+    :param bool pretty_print: Whether to format the JSON string, defaults to ``True``
+    :param book no_log: Hide sensitive values in the log messages
+    :return: JSON string of the object
+    :rtype: str
     """
-    if pretty_print:
-        return json.dumps(obj, default=lambda o: o.__dict__, indent=5)
-    return json.dumps(obj, default=lambda o: o.__dict__)
+    indent = 5 if pretty_print else None
+    if no_log:
+        return json.dumps(obj, default=_to_protected_dict, indent=indent)
+    return json.dumps(obj, default=lambda o: o.__dict__, indent=indent)
 
 
 def toxmlstr(obj, pretty_print=False):
     """
     Convert a Python object to an XML string
 
-   :param object obj: the Python object
-   :param bool pretty_print: whether to format the XML string, defaults to ``False``
-   :return: XML string of the object
-   :rtype: str
+    :param object obj: the Python object
+    :param bool pretty_print: whether to format the XML string, defaults to ``False``
+    :return: XML string of the object
+    :rtype: str
     """
     if obj is None:
         return None

--- a/cterasdk/convert/format.py
+++ b/cterasdk/convert/format.py
@@ -30,7 +30,7 @@ def _to_protected_dict(o):
     return ret
 
 
-def tojsonstr(obj, pretty_print=True, no_log=False):
+def tojsonstr(obj, pretty_print=True, no_log=True):
     """
     Convert a Python object to a JSON string.
 

--- a/cterasdk/core/activation.py
+++ b/cterasdk/core/activation.py
@@ -1,7 +1,6 @@
 import logging
 
 from .base_command import BaseCommand
-from ..convert import tojsonstr
 
 
 class Activation(BaseCommand):
@@ -28,6 +27,6 @@ class Activation(BaseCommand):
 
         response = self._portal.get('/ssoActivation', params)
 
-        logging.getLogger().info('Generated device activation code. %s', tojsonstr(response, False))
+        logging.getLogger().info('Generated device activation code. %s', {'user': username, 'portal': tenant})
 
         return response.code

--- a/cterasdk/core/query.py
+++ b/cterasdk/core/query.py
@@ -12,7 +12,7 @@ def query(CTERAHost, path, param):
 
 def show(CTERAHost, path, param):
     hasMore, objects = query(CTERAHost, path, param)
-    print(tojsonstr(objects))
+    print(tojsonstr(objects, no_log=False))
     return hasMore
 
 

--- a/cterasdk/edge/query.py
+++ b/cterasdk/edge/query.py
@@ -10,7 +10,7 @@ def query(CTERAHost, path, key, value):
 
 
 def show(CTERAHost, path, key, value):
-    print(tojsonstr(query(CTERAHost, path, key, value)))
+    print(tojsonstr(query(CTERAHost, path, key, value), no_log=False))
 
 
 class QueryParam(Object):
@@ -31,10 +31,6 @@ class QueryParamBuilder:
     def __init__(self):
         self.param = QueryParam()
 
-    def include_classname(self):
-        self.param.include_classname()
-        return self
-
     def startFrom(self, startFrom):
         self.param.startFrom = startFrom
         return self
@@ -45,13 +41,6 @@ class QueryParamBuilder:
 
     def include(self, include):
         self.param.include = include  # pylint: disable=attribute-defined-outside-init
-        return self
-
-    def sortBy(self, sortBy):
-        self.param.sortBy = sortBy  # pylint: disable=attribute-defined-outside-init
-
-    def allPortals(self, allPortals):
-        self.param.allPortals = allPortals  # pylint: disable=attribute-defined-outside-init
         return self
 
     def put(self, key, value):

--- a/tests/ut/base_convert.py
+++ b/tests/ut/base_convert.py
@@ -5,8 +5,8 @@ from tests.ut import base
 class TestJSON(base.BaseTest):
 
     @staticmethod
-    def _tojsonstr(value):
-        return tojsonstr(value, False)
+    def _tojsonstr(value, pretty_print=False, no_log=False):
+        return tojsonstr(value, pretty_print, no_log)
 
 
 class TestXML(base.BaseTest):

--- a/tests/ut/test_common_object.py
+++ b/tests/ut/test_common_object.py
@@ -8,8 +8,6 @@ class TestCommonObject(base.BaseTest):
     def test_str(self):
         o = Object()
         o.user = 'user'
-        o.password = 'password'
         object_str = str(o)
         object_str_json = json.loads(object_str)
         self.assertEqual(object_str_json['user'], o.user)
-        self.assertEqual(object_str_json['password'], '*** The Value is Hidden by the SDK ***')

--- a/tests/ut/test_convert_format_json.py
+++ b/tests/ut/test_convert_format_json.py
@@ -1,3 +1,5 @@
+import json
+
 from cterasdk import Object
 from tests.ut import base_convert
 
@@ -47,3 +49,9 @@ class TestFormatObjectJSON(base_convert.TestJSON):
             '}' \
             '}'
         self.assertEqual(base_convert.TestJSON._tojsonstr(o), device_config)
+
+    def test_sensitive_object(self):
+        o = Object()
+        o.password = 'secret'
+        object_str_json = json.loads(base_convert.TestJSON._tojsonstr(o, False, True))
+        self.assertEqual(object_str_json['password'], "*** The Value is Hidden by the SDK ***")


### PR DESCRIPTION
- Move implementation from common/object to covert/format.py (tojsonstr)
- Update client/host functions to use tojsonstr
- Update UT
With this implementation, the SDK does not override the server values and displays debug messages without line breaks