### PR TITLE
Foundation for GlobalAdmin local authentication

### DIFF
--- a/cterasdk/client/cteraclient.py
+++ b/cterasdk/client/cteraclient.py
@@ -1,4 +1,4 @@
-from .http import HTTPClient, ContentType, HTTPException, HTTPResponse, geturi
+from .http import HTTPClient, ContentType, HTTPException, HTTPResponse, geturi, getheaders
 from ..convert import fromxmlstr, toxmlstr
 from ..exception import CTERAClientException
 from ..lib import Command
@@ -12,61 +12,67 @@ class CTERAClient:
     def __init__(self, session_id_key):
         self.http_client = HTTPClient(session_id_key)
 
-    def get(self, baseurl, path, params=None):
-        function = Command(HTTPClient.get, self.http_client, geturi(baseurl, path), params if params else {})
+    def get(self, baseurl, path, params=None, headers=None):
+        function = Command(HTTPClient.get, self.http_client, geturi(baseurl, path),
+                           params if params else {}, getheaders(headers))
         return self._execute(function)
 
-    def download(self, baseurl, path, params):
-        function = Command(HTTPClient.get, self.http_client, geturi(baseurl, path), params, None, True)
+    def download(self, baseurl, path, params, headers=None):
+        function = Command(HTTPClient.get, self.http_client, geturi(baseurl, path), params, getheaders(headers), True)
         return self._execute(function, return_function=CTERAClient.file_descriptor)
 
-    def download_zip(self, baseurl, path, form_data):
-        function = Command(HTTPClient.post, self.http_client, geturi(baseurl, path), ContentType.urlencoded, form_data, True)
+    def download_zip(self, baseurl, path, form_data, headers=None):
+        function = Command(HTTPClient.post, self.http_client, geturi(baseurl, path),
+                           getheaders(headers, ContentType.urlencoded), form_data, True)
         return self._execute(function, return_function=CTERAClient.file_descriptor)
 
-    def get_multi(self, baseurl, path, paths):
-        return self.db(baseurl, path, "get-multi", paths)
+    def get_multi(self, baseurl, path, paths, headers=None):
+        return self.db(baseurl, path, "get-multi", paths, headers)
 
-    def put(self, baseurl, path, data):
-        function = Command(HTTPClient.put, self.http_client, geturi(baseurl, path), ContentType.textplain, toxmlstr(data))
+    def put(self, baseurl, path, data, headers=None):
+        function = Command(HTTPClient.put, self.http_client, geturi(baseurl, path),
+                           getheaders(headers, ContentType.textplain), toxmlstr(data))
         return self._execute(function)
 
-    def post(self, baseurl, path, data):
-        function = Command(HTTPClient.post, self.http_client, geturi(baseurl, path), ContentType.textplain, toxmlstr(data))
+    def post(self, baseurl, path, data, headers=None):
+        function = Command(HTTPClient.post, self.http_client, geturi(baseurl, path),
+                           getheaders(headers, ContentType.textplain), toxmlstr(data))
         return self._execute(function)
 
-    def form_data(self, baseurl, path, form_data):
-        function = Command(HTTPClient.post, self.http_client, geturi(baseurl, path), ContentType.urlencoded, form_data, True)
+    def form_data(self, baseurl, path, form_data, headers=None):
+        function = Command(HTTPClient.post, self.http_client, geturi(baseurl, path),
+                           getheaders(headers, ContentType.urlencoded), form_data, True)
         return self._execute(function)
 
-    def execute(self, baseurl, path, name, param=None):
-        return self._ctera_exec(baseurl, path, 'user-defined', name, param)
+    def execute(self, baseurl, path, name, param=None, headers=None):
+        return self._ctera_exec(baseurl, path, 'user-defined', name, param, headers)
 
-    def delete(self, baseurl, path):
-        function = Command(HTTPClient.delete, self.http_client, geturi(baseurl, path))
+    def delete(self, baseurl, path, headers=None):
+        function = Command(HTTPClient.delete, self.http_client, geturi(baseurl, path), headers)
         return self._execute(function)
 
-    def mkcol(self, baseurl, path):
-        function = Command(HTTPClient.mkcol, self.http_client, geturi(baseurl, path))
+    def mkcol(self, baseurl, path, headers=None):
+        function = Command(HTTPClient.mkcol, self.http_client, geturi(baseurl, path), headers)
         return self._execute(function)
 
-    def db(self, baseurl, path, name, param):
-        return self._ctera_exec(baseurl, path, 'db', name, param)
+    def db(self, baseurl, path, name, param, headers=None):
+        return self._ctera_exec(baseurl, path, 'db', name, param, headers)
 
-    def multipart(self, baseurl, path, form_data):
-        function = Command(HTTPClient.multipart, self.http_client, geturi(baseurl, path), form_data)
+    def multipart(self, baseurl, path, form_data, headers=None):
+        function = Command(HTTPClient.multipart, self.http_client, geturi(baseurl, path), form_data, headers)
         return self._execute(function)
 
-    def upload(self, baseurl, path, form_data):
-        function = Command(HTTPClient.upload, self.http_client, geturi(baseurl, path), form_data)
+    def upload(self, baseurl, path, form_data, headers=None):
+        function = Command(HTTPClient.upload, self.http_client, geturi(baseurl, path), form_data, headers)
         return self._execute(function)
 
-    def _ctera_exec(self, baseurl, path, exec_type, name, param):
+    def _ctera_exec(self, baseurl, path, exec_type, name, param, headers):
         obj = Object()
         obj.type = exec_type
         obj.name = name
         obj.param = param
-        function = Command(HTTPClient.post, self.http_client, geturi(baseurl, path), ContentType.textplain, toxmlstr(obj))
+        function = Command(HTTPClient.post, self.http_client, geturi(baseurl, path),
+                           getheaders(headers, ContentType.textplain), toxmlstr(obj))
         return self._execute(function)
 
     def get_session_id(self):

--- a/cterasdk/lib/utils.py
+++ b/cterasdk/lib/utils.py
@@ -1,0 +1,14 @@
+import base64
+
+
+def merge(d1, d2):
+    d1 = d1 if d1 else {}
+    if d2:
+        d1.update(d2)
+    return d1
+
+
+def b64decode(base64_message):
+    base64_bytes = base64_message.encode('ascii')
+    message_bytes = base64.b64decode(base64_bytes)
+    return message_bytes.decode('ascii')


### PR DESCRIPTION
- Expose the headers parameter in http, cteraclient and host modules
- Allow for headers to be sent from the individual core/edge modules
- Automatically join authorization headers for GlobalAdmin (if exist)
- Join content-type headers in client/cteraclient to contruct a complete list of headers
- Add utils module to combine two dictionaries