### PR TITLE
Add support for setting storage quotas

### DIFF
--- a/cterasdk/common/__init__.py
+++ b/cterasdk/common/__init__.py
@@ -1,4 +1,4 @@
 from .item import Item  # noqa: E402, F401
 from .object import Object  # noqa: E402, F401
 from .datetime_utils import DateTimeUtils  # noqa: E402, F401
-from .utils import merge, union, parse_base_object_ref  # noqa: E402, F401
+from .utils import merge, union, parse_base_object_ref, convert_size, DataUnit  # noqa: E402, F401

--- a/cterasdk/common/utils.py
+++ b/cterasdk/common/utils.py
@@ -27,6 +27,43 @@ def merge(d1, d2):
     return d3
 
 
+class DataUnit:
+    """
+    Data Unit
+
+    :ivar str PB: Petabytes
+    :ivar str TB: Terabytes
+    :ivar str GB: Gigabytes
+    :ivar str MB: Megabytes
+    :ivar str KB: Kilobytes
+    :ivar str B: Bytes
+    """
+    PB = 'PB'
+    TB = 'TB'
+    GB = 'GB'
+    MB = 'MB'
+    KB = 'KB'
+    B = 'B'
+
+
+def convert_size(numeric, u1, u2):
+    """
+    :param str u1: Convert from data unit
+    :param str u2: Convert to data unit
+    """
+    data_units = [DataUnit.B, DataUnit.KB, DataUnit.MB, DataUnit.GB, DataUnit.TB, DataUnit.PB]
+    if u1 not in data_units:
+        raise ValueError("Invalid current unit type %s" % u1)
+    if u2 not in data_units:
+        raise ValueError("Invalid target unit type %s" % u2)
+    offset = (data_units.index(u1) - data_units.index(u2)) * 10
+    if offset > 0:
+        return numeric * (1 << offset)
+    if offset < 0:
+        return numeric / (1 << abs(offset))
+    return numeric
+
+
 class BaseObjectRef(Object):
     """
     Class Representing a Portal Base Object Reference

--- a/cterasdk/core/enum.py
+++ b/cterasdk/core/enum.py
@@ -295,6 +295,7 @@ class PlanItem:
     SA = 'SA'
     Share = 'Share'
     Connect = 'Connect'
+    Storage = 'Storage'
 
 
 class ListFilter:

--- a/tests/ut/test_core_plans.py
+++ b/tests/ut/test_core_plans.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+from cterasdk.exception import InputError
+
 from cterasdk import exception
 from cterasdk.common import Object
 from cterasdk.core import plans
@@ -44,3 +46,24 @@ class TestCorePlans(base_core.BaseCoreTest):
         for key, value in kwargs.items():
             setattr(param, key, value)
         return param
+
+    def _test__get_storage_amount(self, new, existing, expected):
+        self.assertEqual(plans.Plans._get_storage_amount(new, existing), expected)  # pylint: disable=protected-access
+
+    def test__get_storage_amount_no_value(self):
+        self._test__get_storage_amount(None, 100, 100)
+
+    def test__get_storage_amount_int(self):
+        self._test__get_storage_amount(50, 100, 50*2**30)
+
+    def test__get_storage_amount_gb(self):
+        self._test__get_storage_amount("50GB", 100, 50*2**30)
+
+    def test__get_storage_amount_tb(self):
+        self._test__get_storage_amount("50TB", 100, 50*2**40)
+
+    def test__get_storage_amount_pb(self):
+        self._test__get_storage_amount("50PB", 100, 50*2**50)
+
+    def test__get_storage_amount_b(self):
+        self.assertRaises(InputError, plans.Plans._get_storage_amount, "50B", 100)  # pylint: disable=protected-access


### PR DESCRIPTION
Storage quota can be passed as an integer, as a string with no unit
both considered as GB or string with the units GB, TB or PB