### PR TITLE
Support plan auto assignment rules

### DIFF
--- a/cterasdk/__init__.py
+++ b/cterasdk/__init__.py
@@ -3,7 +3,7 @@ from . import config
 
 config.Logging.get()
 
-from .common import Object  # noqa: E402, F401
+from .common import Object, PolicyRule  # noqa: E402, F401
 from .convert import fromjsonstr, tojsonstr, fromxmlstr, toxmlstr  # noqa: E402, F401
 from .exception import CTERAException  # noqa: E402, F401
 from .object import GlobalAdmin, ServicesPortal, Gateway, Agent  # noqa: E402, F401

--- a/cterasdk/common/__init__.py
+++ b/cterasdk/common/__init__.py
@@ -2,3 +2,4 @@ from .item import Item  # noqa: E402, F401
 from .object import Object  # noqa: E402, F401
 from .datetime_utils import DateTimeUtils  # noqa: E402, F401
 from .utils import merge, union, parse_base_object_ref, convert_size, DataUnit  # noqa: E402, F401
+from .types import PolicyRule, PolicyRuleCoverter, StringCriteriaBuilder, ListCriteriaBuilder  # noqa: E402, F401

--- a/cterasdk/common/types.py
+++ b/cterasdk/common/types.py
@@ -3,18 +3,18 @@ from .object import Object
 
 class PolicyRule:
 
-    def __init__(self, value, criteria):
-        self.value = value
+    def __init__(self, assignment, criteria):
+        self.assignment = assignment
         self.criteria = criteria
 
 
 class PolicyRuleCoverter:
 
     @staticmethod
-    def convert(rule, classname, property_name):
+    def convert(rule, classname, property_name, assignment=None):
         param = Object()
         param._classname = classname  # pylint: disable=protected-access
-        setattr(param, property_name, rule.value)
+        setattr(param, property_name, assignment if assignment else rule.assignment)
         param.filterRule = rule.criteria
         return param
 

--- a/cterasdk/common/types.py
+++ b/cterasdk/common/types.py
@@ -1,0 +1,96 @@
+from .object import Object
+
+
+class PolicyRule:
+
+    def __init__(self, value, criteria):
+        self.value = value
+        self.criteria = criteria
+
+
+class PolicyRuleCoverter:
+
+    @staticmethod
+    def convert(rule, classname, property_name):
+        param = Object()
+        param._classname = classname  # pylint: disable=protected-access
+        setattr(param, property_name, rule.value)
+        param.filterRule = rule.criteria
+        return param
+
+
+class Operator(Object):
+
+    def __init__(self, right):
+        self._classname = self.__class__.__name__  # pylint: disable=protected-access
+        self.right = right
+
+
+class IsOperator(Operator):
+    pass
+
+
+class BeginsWithOperator(Operator):
+    pass
+
+
+class EndsWithOperator(Operator):
+    pass
+
+
+class ContainsOperator(Operator):
+    pass
+
+
+class IsOneOfOperator(Operator):
+    pass
+
+
+class AdvancedFilterRule(Object):
+
+    def __init__(self, classname, field, operator):
+        self._classname = self.__class__.__name__  # pylint: disable=protected-access
+        self.className = classname
+        self.fieldName = field
+        self.operator = operator
+
+
+class CriteriaBuilder:
+
+    def __init__(self, criteria_type, criteria_field):
+        self.criteria_type = criteria_type
+        self.criteria_field = criteria_field
+        self.operator = None
+
+    def build(self):
+        return AdvancedFilterRule(self.criteria_type, self.criteria_field, self.operator)
+
+
+class ListCriteriaBuilder(CriteriaBuilder):
+
+    def include(self, values):
+        self.operator = IsOneOfOperator(values)
+        return self
+
+
+class StringCriteriaBuilder(CriteriaBuilder):
+
+    def equals(self, value):
+        self.operator = IsOperator(value)
+        return self
+
+    def startswith(self, value):
+        self.operator = BeginsWithOperator(value)
+        return self
+
+    def endswith(self, value):
+        self.operator = EndsWithOperator(value)
+        return self
+
+    def contains(self, value):
+        self.operator = ContainsOperator(value)
+        return self
+
+    def isoneof(self, values):
+        self.operator = IsOneOfOperator(values)
+        return self

--- a/cterasdk/core/enum.py
+++ b/cterasdk/core/enum.py
@@ -309,3 +309,26 @@ class ListFilter:
     All = 'All'
     Deleted = 'Deleted'
     NonDeleted = 'NonDeleted'
+
+
+class PlanCriteria:
+    """
+    Subscription Plan Auto Assignment Rule Builder Criterias
+
+    :ivar str Username: Username
+    :ivar str Groups: User groups
+    :ivar str Role: User role
+    :ivar str First: User first name
+    :ivar str Last: User last name
+    :ivar str Company: User company
+    :ivar str BillingId: User billing id
+    :ivar str Comment: User comment
+    """
+    Username = 'username'
+    Groups = 'userGroups'
+    Role = 'role'
+    First = 'firstName'
+    Last = 'lastName'
+    Company = 'company'
+    BillingId = 'billingId'
+    Comment = 'comment'

--- a/cterasdk/core/plans.py
+++ b/cterasdk/core/plans.py
@@ -34,6 +34,7 @@ class Plans(BaseCommand):
 
         :param list[str],optional names: List of names of plans
         :param list[str],optional include: List of fields to retrieve, defaults to ['name']
+        :param list[cterasdk.core.query.FilterBuilder],optional filters: List of additional filters, defaults to None
 
         :return: Iterator for all matching Plans
         :rtype: cterasdk.lib.iterator.Iterator
@@ -219,12 +220,8 @@ class PlanAutoAssignPolicy(BaseCommand):
         elif apply_default is True and default:
             policy.defaultPlan = portal_plans.get(default).baseObjectRef
 
-        policy_rules = []
-        for rule in rules:
-            policy_rule = PolicyRuleCoverter.convert(rule, 'PlanAutoAssignmentRule', 'plan',
-                                                     portal_plans.get(rule.assignment).baseObjectRef)
-            policy_rules.append(policy_rule)
-
+        policy_rules = [PolicyRuleCoverter.convert(rule, 'PlanAutoAssignmentRule', 'plan',
+                        portal_plans.get(rule.assignment).baseObjectRef) for rule in rules]
         policy.planAutoAssignmentRules = policy_rules
 
         response = self._portal.execute('', 'setPlanAutoAssignmentRules', policy)

--- a/cterasdk/core/taskmgr.py
+++ b/cterasdk/core/taskmgr.py
@@ -12,7 +12,12 @@ class Task(TaskBase):
         if not match:
             logging.getLogger().error('Invalid task id. %s', {'ref': ref})
             raise InputError('Invalid task id', ref, ['servers/server/bgTasks/107781'])
-        return '/' + match.group(0)
+        return match.group(0)
+
+    def _get_task_status(self):
+        if self.CTERAHost.session().in_tenant_context():
+            return self.CTERAHost.execute('', 'getTaskStatus', self.path)
+        return self.CTERAHost.get('/' + self.path)
 
 
 def wait(CTERAHost, ref):

--- a/cterasdk/core/types.py
+++ b/cterasdk/core/types.py
@@ -2,7 +2,7 @@ from abc import ABC
 from collections import namedtuple
 from ..common import DateTimeUtils, StringCriteriaBuilder, ListCriteriaBuilder
 
-from .enum import PortalAccountType, CollaboratorType, FileAccessMode
+from .enum import PortalAccountType, CollaboratorType, FileAccessMode, PlanCriteria
 
 
 CloudFSFolderFindingHelper = namedtuple('CloudFSFolderFindingHelper', ('name', 'owner'))
@@ -185,25 +185,6 @@ class ShareRecipient:
         if self.type == CollaboratorType.EXT:
             return self.account
         return str(self.account)
-
-
-class Role:
-    Disabled = 'Disabled'
-    EndUser = 'EndUser'
-    ReadWriteAdmin = 'ReadWriteAdmin'
-    ReadOnlyAdmin = 'ReadOnlyAdmin'
-    Support = 'Support'
-
-
-class PlanCriteria:
-    Username = 'username'
-    Groups = 'userGroups'
-    Role = 'role'
-    First = 'firstName'
-    Last = 'lastName'
-    Company = 'company'
-    BillingId = 'billingId'
-    Comment = 'comment'
 
 
 class PlanCriteriaBuilder:

--- a/cterasdk/core/types.py
+++ b/cterasdk/core/types.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from collections import namedtuple
-from ..common import DateTimeUtils
+from ..common import DateTimeUtils, StringCriteriaBuilder, ListCriteriaBuilder
 
 from .enum import PortalAccountType, CollaboratorType, FileAccessMode
 
@@ -185,3 +185,59 @@ class ShareRecipient:
         if self.type == CollaboratorType.EXT:
             return self.account
         return str(self.account)
+
+
+class Role:
+    Disabled = 'Disabled'
+    EndUser = 'EndUser'
+    ReadWriteAdmin = 'ReadWriteAdmin'
+    ReadOnlyAdmin = 'ReadOnlyAdmin'
+    Support = 'Support'
+
+
+class PlanCriteria:
+    Username = 'username'
+    Groups = 'userGroups'
+    Role = 'role'
+    First = 'firstName'
+    Last = 'lastName'
+    Company = 'company'
+    BillingId = 'billingId'
+    Comment = 'comment'
+
+
+class PlanCriteriaBuilder:
+
+    Type = 'PlanCriteria'
+
+    @staticmethod
+    def username():
+        return StringCriteriaBuilder(PlanCriteriaBuilder.Type, PlanCriteria.Username)
+
+    @staticmethod
+    def user_groups():
+        return ListCriteriaBuilder(PlanCriteriaBuilder.Type, PlanCriteria.Groups)
+
+    @staticmethod
+    def role():
+        return ListCriteriaBuilder(PlanCriteriaBuilder.Type, PlanCriteria.Role)
+
+    @staticmethod
+    def first_name():
+        return StringCriteriaBuilder(PlanCriteriaBuilder.Type, PlanCriteria.First)
+
+    @staticmethod
+    def last_name():
+        return StringCriteriaBuilder(PlanCriteriaBuilder.Type, PlanCriteria.Last)
+
+    @staticmethod
+    def company():
+        return StringCriteriaBuilder(PlanCriteriaBuilder.Type, PlanCriteria.Company)
+
+    @staticmethod
+    def billing_id():
+        return StringCriteriaBuilder(PlanCriteriaBuilder.Type, PlanCriteria.BillingId)
+
+    @staticmethod
+    def comment():
+        return StringCriteriaBuilder(PlanCriteriaBuilder.Type, PlanCriteria.Comment)

--- a/cterasdk/edge/taskmgr.py
+++ b/cterasdk/edge/taskmgr.py
@@ -21,6 +21,9 @@ class Task(TaskBase):
         logging.getLogger().error('Could not parse task id. %s', {'ref': ref})
         raise InputError('Invalid task id', ref, [64, '/proc/bgtasks/64'])
 
+    def _get_task_status(self):
+        return self.CTERAHost.get(self.path)
+
 
 def running(CTERAHost):
     return CTERAHost.query('/proc/bgtasks', 'status', 'running')

--- a/cterasdk/lib/task_manager_base.py
+++ b/cterasdk/lib/task_manager_base.py
@@ -33,11 +33,15 @@ class TaskBase(ABC):
     def _get_task_id(self, ref):
         raise NotImplementedError("Subclass must implement _get_task_id")
 
+    @abstractmethod
+    def _get_task_status(self):
+        raise NotImplementedError("Subclass must implement _get_task_status")
+
     def wait(self):
         task = None
         while self.running:
             logging.getLogger().debug('Obtaining task status. %s', {'path': self.path, 'attempt': (self.attempt + 1)})
-            task = self.CTERAHost.get(self.path)
+            task = self._get_task_status()
             logging.getLogger().debug('Task status. %s', tojsonstr(task, False))
             self.increment()
             self.running = task.status == TaskRunningStatus.Running

--- a/docs/source/user_guides/Portal/GlobalAdmin.rst
+++ b/docs/source/user_guides/Portal/GlobalAdmin.rst
@@ -319,7 +319,7 @@ Plan Auto Assignment Rules
    r4 = PolicyRule('ABC', c4)
 
    """Apply the '10TB' plan to read write, read only and support administrators"""
-   roles = [portal_types.Role.ReadWriteAdmin, portal_types.Role.ReadOnlyAdmin, portal_types.Role.Support]
+   roles = [portal_enum.Role.ReadWriteAdmin, portal_enum.Role.ReadOnlyAdmin, portal_enum.Role.Support]
    c5 = portal_types.PlanCriteriaBuilder.role().include(roles).build()
    r5 = PolicyRule('10TB', c5)
 

--- a/docs/source/user_guides/Portal/GlobalAdmin.rst
+++ b/docs/source/user_guides/Portal/GlobalAdmin.rst
@@ -225,6 +225,7 @@ Plans
    - Deleted: Recycle Bin
 
    Quotas (portal_enum.PlanItem):
+   - Storage: Storage Quota, in Gigabytes
    - EV4: CTERA Edge Filer, Up to 4 TB of Local Cache
    - EV8: CTERA Edge Filer, Up to 8 TB of Local Cache
    - EV16: CTERA Edge Filer, Up to 16 TB of Local Cache
@@ -271,6 +272,53 @@ Plans
 
    name = 'good_plan'
    admin.plan.delete(name)
+
+Plan Auto Assignment Rules
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automethod:: cterasdk.core.plans.PlanAutoAssignPolicy.get_policy
+   :noindex:
+
+.. automethod:: cterasdk.core.plans.PlanAutoAssignPolicy.set_policy
+   :noindex:
+
+.. code-block:: python
+
+   """Apply the '100GB' plan to all user names that start with 'adm'"""
+   c1 = portal_types.PlanCriteriaBuilder.username().startswith('adm').build()
+   r1 = PolicyRule('100GB', c1)
+
+   """Apply the '200GB' plan to all user names that end with 'inc'"""
+   c2 = portal_types.PlanCriteriaBuilder.username().endswith('inc').build()
+   r2 = PolicyRule('200GB', c2)
+
+   """Apply the 'Bingo' plan to all user names that contain 'bing'"""
+   c3 = portal_types.PlanCriteriaBuilder.username().contains('bing').build()
+   r3 = PolicyRule('Bingo', c3)
+
+   """Apply the 'ABC' plan to 'alice', 'bob' and 'charlie'"""
+   c4 = portal_types.PlanCriteriaBuilder.username().isoneof(['alice', 'bob', 'charlie']).build()
+   r4 = PolicyRule('ABC', c4)
+
+   """Apply the '10TB' plan to read write, read only and support administrators"""
+   roles = [portal_types.Role.ReadWriteAdmin, portal_types.Role.ReadOnlyAdmin, portal_types.Role.Support]
+   c5 = portal_types.PlanCriteriaBuilder.role().include(roles).build()
+   r5 = PolicyRule('10TB', c5)
+
+   """Apply the 'TechStaff' plan to the 'Product' and 'Support' groups"""
+   c6 = portal_types.PlanCriteriaBuilder.user_groups().include(['Product', 'Support']).build()
+   r6 = PolicyRule('TechStaff', c6)
+
+   admin.plans.auto_assign.set_policy([r1, r2, r3, r4, r5, r6])
+
+   """Remove all policy rules"""
+   admin.plans.auto_assign.set_policy([])
+
+   """Do not assign a default plan if no match applies"""
+   admin.plans.auto_assign.set_policy([], False)
+
+   """Assign 'Default' if no match applies"""
+   admin.plans.auto_assign.set_policy([], True, 'Default')
 
 Servers
 -------

--- a/docs/source/user_guides/Portal/GlobalAdmin.rst
+++ b/docs/source/user_guides/Portal/GlobalAdmin.rst
@@ -208,6 +208,24 @@ Plans
 
    plan = admin.plans.get('good_plan', ['createDate', 'modifiedDate'])
 
+.. automethod:: cterasdk.core.plans.Plans.list_plans
+   :noindex:
+
+.. code-block:: python
+
+   """List plans and include their creation date"""
+   for plan in admin.plans.list_plans(['createDate']):
+       print(plan)
+
+.. automethod:: cterasdk.core.plans.Plans.by_name
+   :noindex:
+
+.. code-block:: python
+
+   """List plans 'PlanOne' and 'PlanTwo'; and retrieve the 'modifiedDate', 'uid' and 'isDefault' properties"""
+   for plan in admin.plans.list_plans(['PlanOne', 'PlanTwo'], ['modifiedDate', 'uid', 'isDefault']):
+       print(plan)
+
 .. automethod:: cterasdk.core.plans.Plans.add
    :noindex:
 

--- a/docs/source/user_guides/Portal/GlobalAdmin.rst
+++ b/docs/source/user_guides/Portal/GlobalAdmin.rst
@@ -223,7 +223,7 @@ Plans
 .. code-block:: python
 
    """List plans 'PlanOne' and 'PlanTwo'; and retrieve the 'modifiedDate', 'uid' and 'isDefault' properties"""
-   for plan in admin.plans.list_plans(['PlanOne', 'PlanTwo'], ['modifiedDate', 'uid', 'isDefault']):
+   for plan in admin.plans.by_name(['PlanOne', 'PlanTwo'], ['modifiedDate', 'uid', 'isDefault']):
        print(plan)
 
 .. automethod:: cterasdk.core.plans.Plans.add


### PR DESCRIPTION
@ygalblum:
- I looked at multiple different ways of solving the separate, yet nested builder that will also allow re-use later on but couldn't make it work. I think the following syntax is acceptable, do you agree?
`criteria = portal_types.PlanCriteriaBuilder().username().isoneof(['alice', 'bob', 'charlie']).build()`
`rule = PolicyRule('Default', criteria)`
The criteria and rule infrastructure can be re-used to support sync exclusions, configuration template assignment, etc. That's why some of the implementation now resides in common/types.py

> Should I change the order of the PolicyRule members? First the criteria and then the value?