### PR TITLE
Saimon/wait for Portal connection

### DIFF
--- a/cterasdk/edge/enum.py
+++ b/cterasdk/edge/enum.py
@@ -296,9 +296,17 @@ class ServicesConnectionState:
     """
     Gateway connection status
 
-    :ivar str Disconnected: The Gateway is disconnected from CTERA Portal
-    :ivar str Connected: The Gateway is connected to CTERA Portal
+    :ivar str ResolvingServers: The Edge Filer is resolving CTERA Portal servers
+    :ivar str Connecting: The Edge Filer is in connecting to CTERA Portal
+    :ivar str Attaching: The Edge Filer is attaching to CTERA Portal
+    :ivar str Authenticating: The Edge Filer is authenticating to CTERA Portal
+    :ivar str Disconnected: The Edge Filer is disconnected from CTERA Portal
+    :ivar str Connected: The Edge Filer is connected to CTERA Portal
     """
+    ResolvingServers = "ResolvingServers"
+    Connecting = "Connecting"
+    Attaching = "Attaching"
+    Authenticating = "Authenticating"
     Disconnected = "Disconnected"
     Connected = "Connected"
 

--- a/cterasdk/edge/services.py
+++ b/cterasdk/edge/services.py
@@ -122,10 +122,10 @@ class Services(BaseCommand):
         task = self._attach(param)
         try:
             TaskManager.wait(self._gateway, task)
-            track(self._gateway, '/status/services/CTERAPortal/connectionState', [enum.ServicesConnectionState.Connected], [],
+            track(self._gateway, '/status/services/CTERAPortal/connectionState', [enum.ServicesConnectionState.Connected],
                   [enum.ServicesConnectionState.ResolvingServers, enum.ServicesConnectionState.Connecting,
                    enum.ServicesConnectionState.Attaching, enum.ServicesConnectionState.Authenticating],
-                  [enum.ServicesConnectionState.Disconnected], 5, 1)
+                  [], [enum.ServicesConnectionState.Disconnected], 20, 1)
             logging.getLogger().info("Connected to Portal.")
         except TaskError as error:
             description = error.task.description

--- a/cterasdk/edge/services.py
+++ b/cterasdk/edge/services.py
@@ -122,7 +122,10 @@ class Services(BaseCommand):
         task = self._attach(param)
         try:
             TaskManager.wait(self._gateway, task)
-            track(self._gateway, '/status/services/CTERAPortal/connectionState', [enum.ServicesConnectionState.Connected], [], [enum.ServicesConnectionState.Connected], [], 5, 1)
+            track(self._gateway, '/status/services/CTERAPortal/connectionState', [enum.ServicesConnectionState.Connected], [],
+                  [enum.ServicesConnectionState.ResolvingServers, enum.ServicesConnectionState.Connecting,
+                   enum.ServicesConnectionState.Attaching, enum.ServicesConnectionState.Authenticating],
+                  [enum.ServicesConnectionState.Disconnected], 5, 1)
             logging.getLogger().info("Connected to Portal.")
         except TaskError as error:
             description = error.task.description

--- a/cterasdk/edge/services.py
+++ b/cterasdk/edge/services.py
@@ -3,7 +3,7 @@ import logging
 from ..lib.task_manager_base import TaskError
 from .licenses import Licenses
 from . import taskmgr as TaskManager
-from ..lib import ask
+from ..lib import ask, track
 from ..common import Object
 from ..exception import CTERAException, InputError, CTERAConnectionError
 from .. import config
@@ -122,6 +122,7 @@ class Services(BaseCommand):
         task = self._attach(param)
         try:
             TaskManager.wait(self._gateway, task)
+            track(self._gateway, '/status/services/CTERAPortal/connectionState', [enum.ServicesConnectionState.Connected], [], [enum.ServicesConnectionState.Connected], [], 5, 1)
             logging.getLogger().info("Connected to Portal.")
         except TaskError as error:
             description = error.task.description

--- a/cterasdk/edge/types.py
+++ b/cterasdk/edge/types.py
@@ -73,6 +73,9 @@ class UserGroupEntry():
         if principal_type not in UserGroupEntry._valid_principal_types:
             raise InputError('Invalid principal type', principal_type, UserGroupEntry._valid_principal_types)
 
+    def __str__(self):
+        return ('\\' + self.name) if self.principal_type in [enum.PrincipalType.LG, enum.PrincipalType.LU] else self.name
+
 
 class ShareAccessControlEntry():
     """

--- a/tests/ut/test_edge_services.py
+++ b/tests/ut/test_edge_services.py
@@ -55,11 +55,11 @@ class TestEdgeServices(base_edge.BaseEdgeTest):  # pylint: disable=too-many-inst
             self._filer,
             '/status/services/CTERAPortal/connectionState',
             [ServicesConnectionState.Connected],
-            [],
             [ServicesConnectionState.ResolvingServers, ServicesConnectionState.Connecting,
              ServicesConnectionState.Attaching, ServicesConnectionState.Authenticating],
             [ServicesConnectionState.Disconnected],
-            5,
+            [],
+            20,
             1)
 
     def test_connect_default_args_success(self):
@@ -89,11 +89,11 @@ class TestEdgeServices(base_edge.BaseEdgeTest):  # pylint: disable=too-many-inst
             self._filer,
             '/status/services/CTERAPortal/connectionState',
             [ServicesConnectionState.Connected],
-            [],
             [ServicesConnectionState.ResolvingServers, ServicesConnectionState.Connecting,
              ServicesConnectionState.Attaching, ServicesConnectionState.Authenticating],
             [ServicesConnectionState.Disconnected],
-            5,
+            [],
+            20,
             1)
 
     def test_connect_tcp_connect_error(self):

--- a/tests/ut/test_edge_services.py
+++ b/tests/ut/test_edge_services.py
@@ -28,6 +28,7 @@ class TestEdgeServices(base_edge.BaseEdgeTest):  # pylint: disable=too-many-inst
 
         self._cttp_port = 995
         self._cttp_service = TCPService(self._server, self._cttp_port)
+        self._tracker_mock = self.patch_call("cterasdk.edge.services.track")
 
     def test_get_services_status(self):
         self._init_filer(get_response=self._get_services_status_response())
@@ -50,6 +51,7 @@ class TestEdgeServices(base_edge.BaseEdgeTest):  # pylint: disable=too-many-inst
         expected_param = self._get_attach_and_save_param(False, use_activation_code=True)
         actual_param = self._filer.execute.call_args[0][2]
         self._assert_equal_objects(actual_param, expected_param)
+        self._tracker_mock.assert_called_once_with(self._filer, '/status/services/CTERAPortal/connectionState', [ServicesConnectionState.Connected], [], [ServicesConnectionState.Connected], [], 5, 1)
 
     def test_connect_default_args_success(self):
         self._init_filer()
@@ -74,6 +76,7 @@ class TestEdgeServices(base_edge.BaseEdgeTest):  # pylint: disable=too-many-inst
         expected_param = self._get_attach_and_save_param(False, use_activation_code=False)
         actual_param = self._filer.execute.call_args_list[1][0][2]  # Access attachAndSave call param
         self._assert_equal_objects(actual_param, expected_param)
+        self._tracker_mock.assert_called_once_with(self._filer, '/status/services/CTERAPortal/connectionState', [ServicesConnectionState.Connected], [], [ServicesConnectionState.Connected], [], 5, 1)
 
     def test_connect_tcp_connect_error(self):
         self._filer.network.tcp_connect = mock.MagicMock(return_value=TCPConnectResult(self._server, self._cttp_port, False))

--- a/tests/ut/test_edge_services.py
+++ b/tests/ut/test_edge_services.py
@@ -51,7 +51,16 @@ class TestEdgeServices(base_edge.BaseEdgeTest):  # pylint: disable=too-many-inst
         expected_param = self._get_attach_and_save_param(False, use_activation_code=True)
         actual_param = self._filer.execute.call_args[0][2]
         self._assert_equal_objects(actual_param, expected_param)
-        self._tracker_mock.assert_called_once_with(self._filer, '/status/services/CTERAPortal/connectionState', [ServicesConnectionState.Connected], [], [ServicesConnectionState.Connected], [], 5, 1)
+        self._tracker_mock.assert_called_once_with(
+            self._filer,
+            '/status/services/CTERAPortal/connectionState',
+            [ServicesConnectionState.Connected],
+            [],
+            [ServicesConnectionState.ResolvingServers, ServicesConnectionState.Connecting,
+             ServicesConnectionState.Attaching, ServicesConnectionState.Authenticating],
+            [ServicesConnectionState.Disconnected],
+            5,
+            1)
 
     def test_connect_default_args_success(self):
         self._init_filer()
@@ -76,7 +85,16 @@ class TestEdgeServices(base_edge.BaseEdgeTest):  # pylint: disable=too-many-inst
         expected_param = self._get_attach_and_save_param(False, use_activation_code=False)
         actual_param = self._filer.execute.call_args_list[1][0][2]  # Access attachAndSave call param
         self._assert_equal_objects(actual_param, expected_param)
-        self._tracker_mock.assert_called_once_with(self._filer, '/status/services/CTERAPortal/connectionState', [ServicesConnectionState.Connected], [], [ServicesConnectionState.Connected], [], 5, 1)
+        self._tracker_mock.assert_called_once_with(
+            self._filer,
+            '/status/services/CTERAPortal/connectionState',
+            [ServicesConnectionState.Connected],
+            [],
+            [ServicesConnectionState.ResolvingServers, ServicesConnectionState.Connecting,
+             ServicesConnectionState.Attaching, ServicesConnectionState.Authenticating],
+            [ServicesConnectionState.Disconnected],
+            5,
+            1)
 
     def test_connect_tcp_connect_error(self):
         self._filer.network.tcp_connect = mock.MagicMock(return_value=TCPConnectResult(self._server, self._cttp_port, False))

--- a/tests/ut/test_edge_services.py
+++ b/tests/ut/test_edge_services.py
@@ -57,8 +57,8 @@ class TestEdgeServices(base_edge.BaseEdgeTest):  # pylint: disable=too-many-inst
             [ServicesConnectionState.Connected],
             [ServicesConnectionState.ResolvingServers, ServicesConnectionState.Connecting,
              ServicesConnectionState.Attaching, ServicesConnectionState.Authenticating],
-            [ServicesConnectionState.Disconnected],
             [],
+            [ServicesConnectionState.Disconnected],
             20,
             1)
 
@@ -91,8 +91,8 @@ class TestEdgeServices(base_edge.BaseEdgeTest):  # pylint: disable=too-many-inst
             [ServicesConnectionState.Connected],
             [ServicesConnectionState.ResolvingServers, ServicesConnectionState.Connecting,
              ServicesConnectionState.Attaching, ServicesConnectionState.Authenticating],
-            [ServicesConnectionState.Disconnected],
             [],
+            [ServicesConnectionState.Disconnected],
             20,
             1)
 


### PR DESCRIPTION
@ygalblum: while developing a script for a client i've found we fail if we dont confirm the filer is `Connected` to the Portal. Ignore the types.py file. I added a __str__ function to support better logging when adding group members to a local group in the future.

One this is approved, i'll draft a release