### PR TITLE
Support enabling SSH daemon

### DIFF
--- a/cterasdk/edge/ssh.py
+++ b/cterasdk/edge/ssh.py
@@ -1,0 +1,50 @@
+import logging
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding, PrivateFormat, PublicFormat, NoEncryption
+from .. import config
+from ..lib import FileSystem
+from ..common import Object
+from .base_command import BaseCommand
+
+
+class SSH(BaseCommand):
+    """ Edge Filer SSH daemon APIs """
+
+    def enable(self, public_key=None, exponent=65537, key_size=2048):
+        """
+        Enable the Edge Filer's SSH daemon
+
+        :param str,optional public_key: A PEM-encoded public key in OpenSSH format.
+         If not specified, an RSA key pair will be generated automatically.
+         The PEM-encoded private key will be saved to the default Downloads directory
+        :param int,optional exponent: The public exponent of the new key, defaults to `65537`
+        :param int,optional key_size: The length of the modulus in bits, defaults to `2048`
+        """
+        param = Object()
+
+        private_key = None
+        if not public_key:
+            private_key = rsa.generate_private_key(public_exponent=exponent, key_size=key_size)
+            public_key = private_key.public_key().public_bytes(Encoding.OpenSSH, PublicFormat.OpenSSH)
+
+        param.publicKey = public_key.decode('utf-8')
+
+        if private_key:
+            dirpath = config.filesystem['dl']
+            logging.getLogger().info('Saving private key.')
+            filepath = FileSystem.instance().save(dirpath, '{}.pem'.format(self._gateway.host()),
+                                                  private_key.private_bytes(Encoding.PEM, PrivateFormat.OpenSSH, NoEncryption()))
+            logging.getLogger().info('Saved private key. %s', {'filepath': filepath, 'format': 'PEM'})
+
+            logging.getLogger().info('Saving public key.')
+            filepath = FileSystem.instance().save(dirpath, '{}.pub'.format(self._gateway.host()), public_key)
+            logging.getLogger().info('Saved public key. %s', {'filepath': filepath, 'format': 'OpenSSH'})
+
+        logging.getLogger().info("Enabling SSH daemon.")
+        self._gateway.execute('/config/device', 'startSSHD', param)
+        logging.getLogger().info("SSH daemon enabled.")
+
+    def disable(self):
+        logging.getLogger().info("Disabling SSH daemon.")
+        self._gateway.execute('/config/device', 'stopSSHD')
+        logging.getLogger().info("SSH daemon disabled.")

--- a/cterasdk/edge/ssh.py
+++ b/cterasdk/edge/ssh.py
@@ -1,6 +1,5 @@
 import logging
-from .. import config
-from ..lib import CryptoServices
+from ..lib import FileSystem, CryptoServices
 from ..common import Object
 from .base_command import BaseCommand
 
@@ -8,24 +7,27 @@ from .base_command import BaseCommand
 class SSH(BaseCommand):
     """ Edge Filer SSH daemon APIs """
 
-    def enable(self, public_key=None, exponent=65537, key_size=2048):
+    def enable(self, public_key=None, public_key_file=None, exponent=65537, key_size=2048):
         """
         Enable the Edge Filer's SSH daemon
 
         :param str,optional public_key: A PEM-encoded public key in OpenSSH format.
-         If not specified, an RSA key pair will be generated automatically.
+         If neither a public key nor public key file were specified, an RSA key pair will be generated automatically.
          The PEM-encoded private key will be saved to the default Downloads directory
+        :param str,optional public_key_file: A path to the public key file
         :param int,optional exponent: The public exponent of the new key, defaults to `65537`
         :param int,optional key_size: The length of the modulus in bits, defaults to `2048`
         """
         param = Object()
 
-        if not public_key:
-            key_pair = CryptoServices.generate_rsa_key_pair(exponent, key_size)
-            public_key = key_pair.public_key
-            key_pair.save(config.filesystem['dl'], self._gateway.host())
+        if public_key is None:
+            if public_key_file is not None:
+                FileSystem.instance().get_local_file_info(public_key_file)
+                public_key = open(public_key_file, 'r').read()
+            else:
+                public_key = CryptoServices.generate_and_save_key_pair(self._gateway.host(), exponent=exponent, key_size=key_size)
 
-        param.publicKey = public_key.decode('utf-8')
+        param.publicKey = public_key
 
         logging.getLogger().info("Enabling SSH daemon.")
         self._gateway.execute('/config/device', 'startSSHD', param)

--- a/cterasdk/edge/ssh.py
+++ b/cterasdk/edge/ssh.py
@@ -1,8 +1,6 @@
 import logging
-from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.primitives.serialization import Encoding, PrivateFormat, PublicFormat, NoEncryption
 from .. import config
-from ..lib import FileSystem
+from ..lib import CryptoServices
 from ..common import Object
 from .base_command import BaseCommand
 
@@ -22,23 +20,12 @@ class SSH(BaseCommand):
         """
         param = Object()
 
-        private_key = None
         if not public_key:
-            private_key = rsa.generate_private_key(public_exponent=exponent, key_size=key_size)
-            public_key = private_key.public_key().public_bytes(Encoding.OpenSSH, PublicFormat.OpenSSH)
+            key_pair = CryptoServices.generate_rsa_key_pair(exponent, key_size)
+            public_key = key_pair.public_key
+            key_pair.save(config.filesystem['dl'], self._gateway.host())
 
         param.publicKey = public_key.decode('utf-8')
-
-        if private_key:
-            dirpath = config.filesystem['dl']
-            logging.getLogger().info('Saving private key.')
-            filepath = FileSystem.instance().save(dirpath, '{}.pem'.format(self._gateway.host()),
-                                                  private_key.private_bytes(Encoding.PEM, PrivateFormat.OpenSSH, NoEncryption()))
-            logging.getLogger().info('Saved private key. %s', {'filepath': filepath, 'format': 'PEM'})
-
-            logging.getLogger().info('Saving public key.')
-            filepath = FileSystem.instance().save(dirpath, '{}.pub'.format(self._gateway.host()), public_key)
-            logging.getLogger().info('Saved public key. %s', {'filepath': filepath, 'format': 'OpenSSH'})
 
         logging.getLogger().info("Enabling SSH daemon.")
         self._gateway.execute('/config/device', 'startSSHD', param)

--- a/cterasdk/lib/__init__.py
+++ b/cterasdk/lib/__init__.py
@@ -6,3 +6,4 @@ from .iterator import Iterator  # noqa: E402, F401
 from .file_access_base import FileAccessBase  # noqa: E402, F401
 from .filesystem import FileSystem  # noqa: E402, F401
 from .tracker import track, ErrorStatus  # noqa: E402, F401
+from .crypto import CryptoServices  # noqa: E402, F401

--- a/cterasdk/lib/crypto.py
+++ b/cterasdk/lib/crypto.py
@@ -1,0 +1,40 @@
+import logging
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding, PrivateFormat, PublicFormat, NoEncryption
+
+from .filesystem import FileSystem
+
+
+class RSAKeyPair:
+
+    def __init__(self, private_key, public_key):
+        self._private_key = private_key
+        self._public_key = public_key
+
+    @property
+    def public_key(self):
+        return self._public_key.public_bytes(Encoding.OpenSSH, PublicFormat.OpenSSH)
+
+    @property
+    def private_key(self):
+        return self._private_key.private_bytes(Encoding.PEM, PrivateFormat.OpenSSH, NoEncryption())
+
+    def save(self, dirpath, filename):
+        filesystem = FileSystem.instance()
+
+        logging.getLogger().info('Saving private key.')
+        path = filesystem.save(dirpath, '{}.pem'.format(filename), self.private_key)
+        logging.getLogger().info('Saved private key. %s', {'filepath': path, 'format': 'PEM'})
+
+        logging.getLogger().info('Saving public key.')
+        path = filesystem.save(dirpath, '{}.pub'.format(filename), self.public_key)
+        logging.getLogger().info('Saved public key. %s', {'filepath': path, 'format': 'OpenSSH'})
+
+
+class CryptoServices:
+
+    @staticmethod
+    def generate_rsa_key_pair(exponent=65537, key_size=2048):
+        private_key = rsa.generate_private_key(public_exponent=exponent, key_size=key_size)
+        public_key = private_key.public_key()
+        return RSAKeyPair(private_key, public_key)

--- a/cterasdk/lib/crypto.py
+++ b/cterasdk/lib/crypto.py
@@ -2,6 +2,7 @@ import logging
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import Encoding, PrivateFormat, PublicFormat, NoEncryption
 
+from .. import config
 from .filesystem import FileSystem
 
 
@@ -19,15 +20,15 @@ class RSAKeyPair:
     def private_key(self):
         return self._private_key.private_bytes(Encoding.PEM, PrivateFormat.OpenSSH, NoEncryption())
 
-    def save(self, dirpath, filename):
+    def save(self, dirpath, key_filename):
         filesystem = FileSystem.instance()
 
         logging.getLogger().info('Saving private key.')
-        path = filesystem.save(dirpath, '{}.pem'.format(filename), self.private_key)
+        path = filesystem.save(dirpath, '{}.pem'.format(key_filename), self.private_key)
         logging.getLogger().info('Saved private key. %s', {'filepath': path, 'format': 'PEM'})
 
         logging.getLogger().info('Saving public key.')
-        path = filesystem.save(dirpath, '{}.pub'.format(filename), self.public_key)
+        path = filesystem.save(dirpath, '{}.pub'.format(key_filename), self.public_key)
         logging.getLogger().info('Saved public key. %s', {'filepath': path, 'format': 'OpenSSH'})
 
 
@@ -38,3 +39,11 @@ class CryptoServices:
         private_key = rsa.generate_private_key(public_exponent=exponent, key_size=key_size)
         public_key = private_key.public_key()
         return RSAKeyPair(private_key, public_key)
+
+    @staticmethod
+    def generate_and_save_key_pair(key_filename, exponent=65537, key_size=2048, dirpath=None):
+        key_pair = CryptoServices.generate_rsa_key_pair(exponent, key_size)
+        if not dirpath:
+            dirpath = config.filesystem['dl']
+        key_pair.save(dirpath, key_filename)
+        return key_pair.public_key.decode('utf-8')

--- a/cterasdk/lib/filesystem.py
+++ b/cterasdk/lib/filesystem.py
@@ -82,8 +82,11 @@ class FileSystem:
     @staticmethod
     def write(filepath, handle):
         with open(filepath, 'w+b') as fd:
-            for chunk in handle.iter_content(chunk_size=8192):
-                fd.write(chunk)
+            if isinstance(handle, bytes):
+                fd.write(handle)
+            else:
+                for chunk in handle.iter_content(chunk_size=8192):
+                    fd.write(chunk)
         logging.getLogger().debug('Saved temporary file. %s', {'path': filepath})
 
     @staticmethod

--- a/cterasdk/object/Gateway.py
+++ b/cterasdk/object/Gateway.py
@@ -22,6 +22,7 @@ from ..edge import network
 from ..edge import nfs
 from ..edge import ntp
 from ..edge import ssl
+from ..edge import ssh
 from ..edge import power
 from ..edge import rsync
 from ..edge import services
@@ -61,6 +62,7 @@ class Gateway(CTERAHost):  # pylint: disable=too-many-instance-attributes
     :ivar cterasdk.edge.sync.Sync sync: Object holding the Gateway Sync APIs
     :ivar cterasdk.edge.cache.Cache cache: Object holding the Gateway Cache APIs
     :ivar cterasdk.edge.ssl.SSL ssl: Object holding the Gateway SSL APIs
+    :ivar cterasdk.edge.ssl.SSH ssh: Object holding the Gateway SSH APIs
     :ivar cterasdk.edge.power.Power power: Object holding the Gateway Power APIs
     :ivar cterasdk.edge.users.Users users: Object holding the Gateway Users APIs
     :ivar cterasdk.edge.groups.Groups groups: Object holding the Gateway Groups APIs
@@ -111,6 +113,7 @@ class Gateway(CTERAHost):  # pylint: disable=too-many-instance-attributes
         self.sync = sync.Sync(self)
         self.cache = cache.Cache(self)
         self.ssl = ssl.SSL(self)
+        self.ssh = ssh.SSH(self)
         self.power = power.Power(self)
         self.users = users.Users(self)
         self.groups = groups.Groups(self)
@@ -166,6 +169,7 @@ class Gateway(CTERAHost):  # pylint: disable=too-many-instance-attributes
             'sync',
             'cache',
             'ssl',
+            'ssh',
             'power',
             'users',
             'groups',

--- a/docs/source/api/cterasdk.edge.ssh.rst
+++ b/docs/source/api/cterasdk.edge.ssh.rst
@@ -1,7 +1,7 @@
-cterasdk.edge.ssl module
+cterasdk.edge.ssh module
 ========================
 
-.. automodule:: cterasdk.edge.ssl
+.. automodule:: cterasdk.edge.ssh
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/user_guides/Gateway/Gateway.rst
+++ b/docs/source/user_guides/Gateway/Gateway.rst
@@ -154,7 +154,7 @@ Core Methods
 
    print(bgTask)
 
-.. seealso:: Execute the file-eviction process: :py:func:`Gateway.force_eviction()`, Reboot the Gateway: :py:func:`Gateway.reboot()`, Execute tcp connect: :py:func:`Gateway.tcp_connect()`
+.. seealso:: Execute the file-eviction process: :py:func:`cterasdk.edge.cache.Cache.force_eviction()`, Reboot the Gateway: :py:func:`cterasdk.edge.power.reboot()`, Execute tcp connect: :py:func:`Gateway.tcp_connect()`
 
 .. automethod:: cterasdk.object.Gateway.Gateway.add
    :noindex:
@@ -502,7 +502,7 @@ Active Directory
 
    filer.directoryservice.advanced_mapping('CTERA', 200001, 5000001)
 
-.. note:: to retrieve a list of domain flat names, use :py:func:`Gateway.domains()`
+.. note:: to retrieve a list of domain flat names, use :py:func:`cterasdk.edge.directoryservice.domains()`
 
 .. automethod:: cterasdk.edge.directoryservice.DirectoryService.disconnect
    :noindex:
@@ -566,7 +566,7 @@ Cloud Services
 .. automethod:: cterasdk.edge.services.Services.activate
    :noindex:
 
-   This method's behavior is identical to :py:func:`Gateway.connect()`
+   This method's behavior is identical to :py:func:`cterasdk.edge.services.Services.connect()`
 
 .. code-block:: python
 
@@ -598,7 +598,7 @@ Applying a License
 
    filer.license.apply('EV32')
 
-.. note:: you can specify a license upon connecting the Gateway to CTERA Portal. See :py:func:`Gateway.connect()`
+.. note:: you can specify a license upon connecting the Gateway to CTERA Portal. See :py:func:`cterasdk.edge.services.Services.connect()`
 
 Caching
 =======
@@ -1154,3 +1154,37 @@ Telnet Access
 .. code-block:: python
 
    filer.telnet.disable()
+
+
+SSH Access
+^^^^^^^^^^
+.. automethod:: cterasdk.edge.ssh.SSH.enable
+   :noindex:
+
+.. code-block:: python
+
+   """Enable SSH access"""
+   filer.ssh.enable()
+
+   """Generate an RSA key pair and enable SSH access"""
+
+   from cryptography.hazmat.primitives.asymmetric import rsa
+   from cryptography.hazmat.primitives.serialization import Encoding, PrivateFormat, PublicFormat, NoEncryption
+
+   private_key = rsa.generate_private_key(public_exponent=exponent, key_size=key_size)
+   public_key = private_key.public_key().public_bytes(Encoding.OpenSSH, PublicFormat.OpenSSH).decode('utf-8')
+
+   filer.ssh.enable(public_key)
+
+   """Print PEM-encoded RSA private key"""
+   print(private_key.private_bytes(Encoding.PEM, PrivateFormat.OpenSSH, NoEncryption()).decode('utf-8'))
+
+   """Print OpenSSH formatted RSA public key"""
+   print(public_key)
+
+.. automethod:: cterasdk.edge.ssh.SSH.disable
+   :noindex:
+
+.. code-block:: python
+
+   filer.ssh.disable()

--- a/docs/source/user_guides/Gateway/Gateway.rst
+++ b/docs/source/user_guides/Gateway/Gateway.rst
@@ -1166,6 +1166,10 @@ SSH Access
    """Enable SSH access"""
    filer.ssh.enable()
 
+   """Enable SSH access using a public key file"""
+   filer.ssh.enable(public_key_file='./public_key.pub')  # relative to the current directory
+   filer.ssh.enable(public_key_file='C:\\Users\\jsmith\\Desktop\\public_key.pub')  # full path
+
    """Generate an RSA key pair and enable SSH access"""
 
    from cryptography.hazmat.primitives.asymmetric import rsa

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.23
 requests-toolbelt
+cryptography

--- a/tests/ut/nose2.cfg
+++ b/tests/ut/nose2.cfg
@@ -14,6 +14,7 @@ clear-handlers = True
 filter =
 	-nose
 	-requests
+  -cryptography
 
 [junit-xml]
 always-on = True


### PR DESCRIPTION
@toddatctera: FYI. This won't SSH to the filer and perform the challenge response (this will be done manually), but it does offer a way to initialize the SSH daemon using a public key (either provided by the user, or auto generated by the SDK)