### PR TITLE
Add partial support for Portal configuration templates:

### DIFF
--- a/cterasdk/common/__init__.py
+++ b/cterasdk/common/__init__.py
@@ -3,4 +3,4 @@ from .object import Object  # noqa: E402, F401
 from .datetime_utils import DateTimeUtils  # noqa: E402, F401
 from .utils import merge, union, parse_base_object_ref, convert_size, df_military_time, DataUnit  # noqa: E402, F401
 from .types import PolicyRule, PolicyRuleConverter, StringCriteriaBuilder, IntegerCriteriaBuilder, DateTimeCriteriaBuilder,  \
-                   ListCriteriaBuilder, ThrottlingRuleBuilder, ThrottlingRule  # noqa: E402, F401
+                   ListCriteriaBuilder, ThrottlingRuleBuilder, ThrottlingRule, FilterBackupSet, FileFilterBuilder  # noqa: E402, F401

--- a/cterasdk/common/enum.py
+++ b/cterasdk/common/enum.py
@@ -20,3 +20,31 @@ class DayOfWeek:
     Weekdays = [Monday, Tuesday, Wednesday, Thursday, Friday]
     Weekend = [Saturday, Sunday]
     All = [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday]
+
+
+class FileCriteria:
+    """
+    File Criteria
+
+    :ivar str Name: File name
+    :ivar str Path: File path
+    :ivar str Type: File type
+    :ivar str Size: File size
+    :ivar str Modified: Last modified
+    """
+    Name = 'FileName'
+    Path = 'PathName'
+    Type = 'FileType'
+    Size = 'FileSize'
+    Modified = 'LastModified'
+
+
+class BooleanFunction:
+    """
+    Boolean function
+
+    :ivar str AND: AND
+    :ivar str AND: OR
+    """
+    AND = 'AND'
+    OR = 'OR'

--- a/cterasdk/common/types.py
+++ b/cterasdk/common/types.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from .object import Object
 from .utils import df_military_time, day_of_week
+from .enum import FileCriteria, BooleanFunction
 
 
 class PolicyRule:
@@ -256,3 +257,77 @@ class ThrottlingRuleBuilder:
         if errors:
             raise ValueError('No value for required field: %s' % errors)
         return self.param
+
+
+class FileFilterBuilder:
+
+    Type = 'File'
+
+    @staticmethod
+    def extensions():
+        return ListCriteriaBuilder(FileFilterBuilder.Type, FileCriteria.Type)
+
+    @staticmethod
+    def names():
+        return ListCriteriaBuilder(FileFilterBuilder.Type, FileCriteria.Name)
+
+    @staticmethod
+    def name():
+        return StringCriteriaBuilder(FileFilterBuilder.Type, FileCriteria.Name)
+
+    @staticmethod
+    def paths():
+        return ListCriteriaBuilder(FileFilterBuilder.Type, FileCriteria.Path)
+
+    @staticmethod
+    def path():
+        return StringCriteriaBuilder(FileFilterBuilder.Type, FileCriteria.Path)
+
+    @staticmethod
+    def size():
+        return IntegerCriteriaBuilder(FileFilterBuilder.Type, FileCriteria.Size)
+
+    @staticmethod
+    def last_modified():
+        return DateTimeCriteriaBuilder(FileFilterBuilder.Type, FileCriteria.Modified)
+
+
+class DirectoryEntryFactory:
+
+    @staticmethod
+    def root(included):
+        return DirEntry('root', included=included)
+
+
+class FileEntry(Object):
+
+    def __init__(self, name, display_name=None, included=None):
+        self.name = name
+        self.displayName = display_name
+        self.isIncluded = included
+
+
+class DirEntry(FileEntry):
+
+    def __init__(self, name, display_name=None, included=None, children=None):
+        super().__init__(name, display_name, included)
+        self.children = children
+
+
+class BackupSet(Object):
+
+    def __init__(self, name, directory_tree=None, filter_rules=None, defaults_dirs=None,
+                 template_dirs=None, enabled=True, boolean_function=None, comment=None):
+        self._classname = self.__class__.__name__  # pylint: disable=protected-access
+        self.name = name
+        self.isEnabled = enabled
+        self.directoryTree = directory_tree if directory_tree else DirectoryEntryFactory.root(True)
+        self.booleanFunction = boolean_function if boolean_function else BooleanFunction.AND
+        self.templateDirectories = template_dirs
+        self.defaultDirs = defaults_dirs
+        self.comment = comment
+        self.filterRules = filter_rules
+
+
+class FilterBackupSet(BackupSet):
+    pass

--- a/cterasdk/core/buckets.py
+++ b/cterasdk/core/buckets.py
@@ -38,7 +38,7 @@ class Buckets(BaseCommand):
 
     def add(self, name, bucket, read_only=False, dedicated_to=None):
         """
-        Get a Bucket
+        Add a Bucket
 
         :param str name: Name of the bucket
         :param cterasdk.core.types.Bucket bucket: Storage bucket to add

--- a/cterasdk/core/enum.py
+++ b/cterasdk/core/enum.py
@@ -398,3 +398,35 @@ class BucketType:
     Nutanix = 'Nutanix'
     Wasabi = 'WasabiS3'
     Google = 'GoogleS3'
+
+
+class EnvironmentVariables:
+    """
+    Environment Variables.\n
+    Some environment variables are applicable across platforms (i.e. Windows, Linux), while others are limited to a designated platform
+
+    :ivar str ALLUSERSPROFILE: All users profile
+    :ivar str WINDIR: Windows directory
+    :ivar str TEMP: Temp directory
+    :ivar str SYSTEMDRIVE: System drive
+    :ivar str PROGRAMFILES: Program files
+    :ivar str APPDATA: Application data
+    :ivar str USERPROFILE: Current user profile
+    :ivar str PRIMARYUSER: Primary user
+    :ivar str USERS: Users directory (CTERA Edge Filer)
+    :ivar str AGENTS: Agents directory (CTERA Edge Filer)
+    :ivar str SYNCS: Syncs directory (CTERA Edge Filer)
+    :ivar str PROJECTS: Projects directory (CTERA Edge Filer)
+    """
+    ALLUSERSPROFILE = '$ALLUSERSPROFILE'
+    WINDIR = '$WINDIR'
+    TEMP = '$TEMP'
+    SYSTEMDRIVE = '$SYSTEMDRIVE'
+    PROGRAMFILES = '$PROGRAMFILES'
+    APPDATA = '$APPDATA'
+    USERPROFILE = '$USERPROFILE'
+    USERS = '$USERS'
+    AGENTS = '$AGENTS'
+    SYNCS = '$SYNCS'
+    PROJECTS = '$PROJECTS'
+    PRIMARYUSER = '$PRIMARYUSER'

--- a/cterasdk/core/templates.py
+++ b/cterasdk/core/templates.py
@@ -1,0 +1,133 @@
+import logging
+
+from ..common import union, Object
+from ..exception import CTERAException
+from .base_command import BaseCommand
+from . import query
+
+
+class Templates(BaseCommand):
+    """
+    Portal Configuration Template APIs
+    """
+
+    default = ['name']
+
+    def __init__(self, portal):
+        super().__init__(portal)
+        self.auto_assign = TemplateAutoAssignPolicy(self._portal)
+
+    def _get_entire_object(self, name):
+        try:
+            return self._portal.get('/deviceTemplates/%s' % name)
+        except CTERAException as error:
+            raise CTERAException('Failed to get template', error)
+
+    def get(self, name, include=None):
+        """
+        Get a Configuration Template
+
+        :param str name: Name of the template
+        :param list[str] include: List of fields to retrieve, defaults to ``['name']``
+        """
+        include = union(include or [], Templates.default)
+        include = ['/' + attr for attr in include]
+        template = self._portal.get_multi('/deviceTemplates/' + name, include)
+        if template.name is None:
+            raise CTERAException('Could not find template', None, name=name)
+        return template
+
+    def add(self, name, description=None, include_sets=None, exclude_sets=None):
+        """
+        Add a Configuration Template
+
+        :param str name: Name of the template
+        """
+        param = Object()
+        param._classname = 'DeviceTemplate'  # pylint: disable=protected-access
+        param.name = name
+        param.description = description
+
+        param.deviceSettings = Object()
+        param.deviceSettings._classname = 'DeviceTemplateSettings'  # pylint: disable=protected-access
+
+        if include_sets or exclude_sets:
+            param.deviceSettings.backup = Object()
+            param.deviceSettings.backup._classname = 'BackupTemplate'  # pylint: disable=protected-access
+            param.deviceSettings.backup.backupPolicy = Object()
+            param.deviceSettings.backup.backupPolicy._classname = 'BackupPolicyTemplate'  # pylint: disable=protected-access
+            if include_sets:
+                param.deviceSettings.backup.backupPolicy.includeSets = include_sets
+            if exclude_sets:
+                param.deviceSettings.backup.backupPolicy.excludeSets = exclude_sets
+
+        logging.getLogger().info('Adding template. %s', {'name': name})
+        response = self._portal.add('/deviceTemplates', param)
+        logging.getLogger().info('Template added. %s', {'name': name})
+        return response
+
+    def list_templates(self, include=None):
+        """
+        List Configuration Templates.\n
+        To retrieve templates, you must first browse the tenant, using: `GlobalAdmin.portals.browse()`
+
+        :param list[str],optional include: List of fields to retrieve, defaults to ``['name']``
+        """
+        include = union(include or [], Templates.default)
+        param = query.QueryParamBuilder().include(include).build()
+        return query.iterator(self._portal, '/deviceTemplates', param)
+
+    def delete(self, name):
+        """
+        Delete a Configuration Template
+
+        :param str name: Name of the template
+        """
+        logging.getLogger().info('Deleting template. %s', {'name': name})
+        response = self._portal.delete('/deviceTemplates/%s' % name)
+        logging.getLogger().info('Template deleted. %s', {'name': name})
+        return response
+
+    def set_default(self, name, wait=False):
+        """
+        Set a Configuration Template as the default template
+
+        :param str name: Name of the template
+        :param bool,optional wait: Wait for all changes to apply, defaults to `False`
+        """
+        logging.getLogger().info('Setting default template. %s', {'name': name})
+        response = self._portal.execute('/deviceTemplates/%s' % name, 'setAsDefault')
+        self.auto_assign.apply_changes(wait=wait)
+        logging.getLogger().info('Set default template. %s', {'name': name})
+        return response
+
+    def remove_default(self, name, wait=False):
+        """
+        Set a Configuration Template not to be the default template
+
+        :param str name: Name of the template
+        :param bool,optional wait: Wait for all changes to apply, defaults to `False`
+        """
+        template = self.get(name, include=['isDefault'])
+        if template.isDefault:
+            logging.getLogger().info('Removing default template. %s', {'name': name})
+            response = self._portal.execute('', 'removeDefaultDeviceTemplate')
+            logging.getLogger().info('Removed default template. %s', {'name': name})
+            self.auto_assign.apply_changes(wait=wait)
+            return response
+        logging.getLogger().info('Template not set as default. %s', {'name': name})
+        return None
+
+
+class TemplateAutoAssignPolicy(BaseCommand):
+
+    def apply_changes(self, wait=False):
+        """
+        Apply provisioning changes.\n
+
+        :param bool,optional wait: Wait for all changes to apply, defaults to `False`
+        """
+        task = self._portal.execute('', 'applyAutoAssignmentRules')
+        if wait:
+            task = self._portal.tasks.wait(task)
+        return task

--- a/cterasdk/edge/enum.py
+++ b/cterasdk/edge/enum.py
@@ -357,34 +357,6 @@ class BackupConfStatusID:
     GetFoldersList = "GetFoldersList"
 
 
-class FileCriteria:
-    """
-    Cloud Sync Exclusion Builder File Criteria
-
-    :ivar str Name: File name
-    :ivar str Path: File path
-    :ivar str Type: File type
-    :ivar str Size: File size
-    :ivar str Modified: Last modified
-    """
-    Name = 'FileName'
-    Path = 'PathName'
-    Type = 'FileType'
-    Size = 'FileSize'
-    Modified = 'LastModified'
-
-
-class BooleanFunction:
-    """
-    Boolean function
-
-    :ivar str AND: AND
-    :ivar str AND: OR
-    """
-    AND = 'AND'
-    OR = 'OR'
-
-
 class Traffic:
     """
     Traffic type

--- a/cterasdk/edge/sync.py
+++ b/cterasdk/edge/sync.py
@@ -2,9 +2,8 @@ import logging
 
 from ..lib import track, ErrorStatus
 from .enum import Mode, SyncStatus, Acl
-from .types import FilterBackupSet, FileExclusionBuilder
 from .base_command import BaseCommand
-from ..common import ThrottlingRule
+from ..common import ThrottlingRule, FilterBackupSet, FileFilterBuilder
 
 
 class Sync(BaseCommand):
@@ -116,7 +115,7 @@ class Sync(BaseCommand):
     def exclude_files(self, extensions=None, filenames=None, paths=None, custom_exclusion_rules=None):
         """
         Exclude files from Cloud Sync. This method will override any existing file exclusion rules
-        Use :func:`cterasdk.edge.types.FileExclusionBuilder` to build custom file exclusion rules`
+        Use :func:`cterasdk.common.types.FileFilterBuilder` to build custom file exclusion rules`
 
         :param list[str] extensions: List of file extensions
         :param list[str] filenames: List of file names
@@ -126,15 +125,15 @@ class Sync(BaseCommand):
         rules = list()
         if extensions:
             param = FilterBackupSet('List of file extensions to exclude from sync',
-                                    filter_rules=[FileExclusionBuilder.extensions().include(extensions).build()])
+                                    filter_rules=[FileFilterBuilder.extensions().include(extensions).build()])
             rules.append(param)
         if filenames:
             param = FilterBackupSet('List of file names to exclude from sync',
-                                    filter_rules=[FileExclusionBuilder.names().include(filenames).build()])
+                                    filter_rules=[FileFilterBuilder.names().include(filenames).build()])
             rules.append(param)
         if paths:
             param = FilterBackupSet('List of file paths to exclude from sync',
-                                    filter_rules=[FileExclusionBuilder.paths().include(filenames).build()])
+                                    filter_rules=[FileFilterBuilder.paths().include(filenames).build()])
             rules.append(param)
         if custom_exclusion_rules:
             rules.extend(custom_exclusion_rules)

--- a/cterasdk/edge/types.py
+++ b/cterasdk/edge/types.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 from . import enum
-from ..common import StringCriteriaBuilder, IntegerCriteriaBuilder, ListCriteriaBuilder, DateTimeCriteriaBuilder, Object
+from ..common import Object
 from ..exception import InputError
 
 
@@ -211,77 +211,3 @@ class RemoveShareAccessControlEntry(UserGroupEntry):
     :ivar cterasdk.edge.enum.PrincipalType principal_type: Principal type of the ACL
     :ivar str name: The name of the user or group
     """
-
-
-class FileExclusionBuilder:
-
-    Type = 'File'
-
-    @staticmethod
-    def extensions():
-        return ListCriteriaBuilder(FileExclusionBuilder.Type, enum.FileCriteria.Type)
-
-    @staticmethod
-    def names():
-        return ListCriteriaBuilder(FileExclusionBuilder.Type, enum.FileCriteria.Name)
-
-    @staticmethod
-    def name():
-        return StringCriteriaBuilder(FileExclusionBuilder.Type, enum.FileCriteria.Name)
-
-    @staticmethod
-    def paths():
-        return ListCriteriaBuilder(FileExclusionBuilder.Type, enum.FileCriteria.Path)
-
-    @staticmethod
-    def path():
-        return StringCriteriaBuilder(FileExclusionBuilder.Type, enum.FileCriteria.Path)
-
-    @staticmethod
-    def size():
-        return IntegerCriteriaBuilder(FileExclusionBuilder.Type, enum.FileCriteria.Size)
-
-    @staticmethod
-    def last_modified():
-        return DateTimeCriteriaBuilder(FileExclusionBuilder.Type, enum.FileCriteria.Modified)
-
-
-class DirectoryEntryFactory:
-
-    @staticmethod
-    def root(included):
-        return DirEntry('root', included=included)
-
-
-class FileEntry(Object):
-
-    def __init__(self, name, display_name=None, included=None):
-        self.name = name
-        self.displayName = display_name
-        self.isIncluded = included
-
-
-class DirEntry(FileEntry):
-
-    def __init__(self, name, display_name=None, included=None, children=None):
-        super().__init__(name, display_name, included)
-        self.children = children
-
-
-class BackupSet(Object):
-
-    def __init__(self, name, directory_tree=None, filter_rules=None, defaults_dirs=None,
-                 template_dirs=None, enabled=True, boolean_function=None, comment=None):
-        self._classname = self.__class__.__name__  # pylint: disable=protected-access
-        self.name = name
-        self.isEnabled = enabled
-        self.directoryTree = directory_tree if directory_tree else DirectoryEntryFactory.root(True)
-        self.booleanFunction = boolean_function if boolean_function else enum.BooleanFunction.AND
-        self.templateDirectories = template_dirs
-        self.defaultDirs = defaults_dirs
-        self.comment = comment
-        self.filterRules = filter_rules
-
-
-class FilterBackupSet(BackupSet):
-    pass

--- a/cterasdk/object/Portal.py
+++ b/cterasdk/object/Portal.py
@@ -20,6 +20,7 @@ from ..core import zones
 from ..core import setup
 from ..core import startup
 from ..core import taskmgr
+from ..core import templates
 from ..core import uri
 from ..core import files
 
@@ -38,6 +39,7 @@ class Portal(CTERAHost):  # pylint: disable=too-many-instance-attributes
     :ivar cterasdk.core.logs.Logs logs: Object holding the Portal logs APIs
     :ivar cterasdk.core.cloudfs.CloudFS cloudfs: Object holding the Portal CloudFS APIs
     :ivar cterasdk.core.taskmgr.Tasks tasks: Object holding the Portal Background Tasks APIs
+    :ivar cterasdk.core.templates.Templates templates: Object holding the Portal Configuration Templates APIs
     :ivar cterasdk.core.files.browser.FileBrowser files: Object holding the Portal File Browsing APIs
     """
 
@@ -60,6 +62,7 @@ class Portal(CTERAHost):  # pylint: disable=too-many-instance-attributes
         self.files = files.FileBrowser(self, self.file_browser_base_path)
         self.logs = logs.Logs(self)
         self.tasks = taskmgr.Tasks(self)
+        self.templates = templates.Templates(self)
 
     @property
     def base_api_url(self):
@@ -98,7 +101,8 @@ class Portal(CTERAHost):  # pylint: disable=too-many-instance-attributes
             'activation',
             'files',
             'logs',
-            'tasks'
+            'tasks',
+            'templates'
         ]
 
     @property

--- a/docs/source/api/cterasdk.core.rst
+++ b/docs/source/api/cterasdk.core.rst
@@ -40,6 +40,7 @@ Submodules
    cterasdk.core.setup
    cterasdk.core.startup
    cterasdk.core.taskmgr
+   cterasdk.core.templates
    cterasdk.core.types
    cterasdk.core.union
    cterasdk.core.users

--- a/docs/source/api/cterasdk.core.templates.rst
+++ b/docs/source/api/cterasdk.core.templates.rst
@@ -1,0 +1,7 @@
+cterasdk.core.templates module
+==============================
+
+.. automodule:: cterasdk.core.templates
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api/cterasdk.edge.rst
+++ b/docs/source/api/cterasdk.edge.rst
@@ -42,6 +42,7 @@ Submodules
    cterasdk.edge.network
    cterasdk.edge.nfs
    cterasdk.edge.ntp
+   cterasdk.edge.ssh
    cterasdk.edge.ssl
    cterasdk.edge.power
    cterasdk.edge.query

--- a/docs/source/user_guides/Gateway/Gateway.rst
+++ b/docs/source/user_guides/Gateway/Gateway.rst
@@ -741,9 +741,9 @@ Cloud Sync
 
    Exclude files that their name starts with 'tmp' and smaller than 1 MB (1,048,576 bytes)
    """
-   name_filter_rule = gateway_types.FileExclusionBuilder.name().startswith('tmp')
-   size_filter_rule = gateway_types.FileExclusionBuilder.size().less_than(1048576)
-   exclusion_rule = gateway_types.FilterBackupSet('Custom exclusion rule', filter_rules=[name_filter_rule, size_filter_rule])
+   name_filter_rule = common_types.FileFilterBuilder.name().startswith('tmp')
+   size_filter_rule = common_types.FileFilterBuilder.size().less_than(1048576)
+   exclusion_rule = common_types.FilterBackupSet('Custom exclusion rule', filter_rules=[name_filter_rule, size_filter_rule])
 
    filer.sync.exclude_files(custom_exclusion_rules=[exclusion_rule])
 

--- a/docs/source/user_guides/Portal/GlobalAdmin.rst
+++ b/docs/source/user_guides/Portal/GlobalAdmin.rst
@@ -404,6 +404,68 @@ Plan Auto Assignment Rules
    """Assign 'Default' if no match applies"""
    admin.plans.auto_assign.set_policy([], True, 'Default')
 
+Configuration Templates
+-----------------------
+
+.. automethod:: cterasdk.core.templates.Templates.get
+   :noindex:
+
+.. code-block:: python
+
+   admin.templates.get('MyTemplate')
+
+.. automethod:: cterasdk.core.templates.Templates.list_templates
+   :noindex:
+
+.. code-block:: python
+
+   for template in admin.templates.list_templates(include=['name', 'description', 'modifiedDate']):
+       print(template.name, template.description, template.modifiedDate)
+
+.. automethod:: cterasdk.core.templates.Templates.add
+   :noindex:
+
+.. code-block:: python
+
+   """Include all 'pptx', 'xlsx' and 'docx' file types for all users"""
+   docs = common_types.FileFilterBuilder.extensions().include(['pptx', 'xlsx', 'docx']).build()
+   include_sets = common_types.FilterBackupSet('Documents', filter_rules=[docs],
+                                                         template_dirs=[portal_enum.EnvironmentVariables.ALLUSERSPROFILE])
+
+   """Exclude all 'cmd', 'exe' and 'bat' file types for all users"""
+   programs = common_types.FileFilterBuilder.extensions().include(['cmd', 'exe', 'bat']).build()
+   exclude_sets = common_types.FilterBackupSet('Programs', filter_rules=[programs],
+                                                           template_dirs=[portal_enum.EnvironmentVariables.ALLUSERSPROFILE])
+
+   admin.templates.add('MyTemplate', 'woohoo', include_sets=[include_sets], exclude_sets=[exclude_sets])
+
+.. automethod:: cterasdk.core.templates.Templates.set_default
+   :noindex:
+
+.. code-block:: python
+
+   admin.templates.set_default('MyTemplate')
+
+   admin.templates.set_default('MyTemplate', wait=True)  # wait for template changes to apply
+
+.. automethod:: cterasdk.core.templates.Templates.remove_default
+   :noindex:
+
+.. code-block:: python
+
+   admin.templates.remove_default('MyTemplate')
+
+   admin.templates.remove_default('MyTemplate', wait=True)  # wait for template changes to apply
+
+.. automethod:: cterasdk.core.templates.TemplateAssignPolicy.apply_changes
+   :noindex:
+
+.. code-block:: python
+
+   admin.templates.auto_assign.apply_changes()
+
+   admin.templates.auto_assign.apply_changes(wait=True)  # wait for template changes to apply
+
 Servers
 -------
 .. automethod:: cterasdk.core.servers.Servers.list_servers

--- a/tests/ut/test_core_templates.py
+++ b/tests/ut/test_core_templates.py
@@ -1,0 +1,70 @@
+from unittest import mock
+
+from cterasdk.common import Object
+from cterasdk.core import templates
+from tests.ut import base_core
+
+
+class TestCoreTemplates(base_core.BaseCoreTest):
+
+    def setUp(self):
+        super().setUp()
+        self._template = 'Template'
+        self._template_classname = 'DeviceTemplate'
+
+    def test_get_template_default_attrs(self):
+        get_multi_response = self._get_template_object(name=self._template)
+        self._init_global_admin(get_multi_response=get_multi_response)
+        ret = templates.Templates(self._global_admin).get(self._template)
+        self._global_admin.get_multi.assert_called_once_with('/deviceTemplates/' + self._template, mock.ANY)
+        expected_include = ['/' + attr for attr in templates.Templates.default]
+        actual_include = self._global_admin.get_multi.call_args[0][1]
+        self.assertEqual(len(expected_include), len(actual_include))
+        for attr in expected_include:
+            self.assertIn(attr, actual_include)
+        self.assertEqual(ret.name, self._template)
+
+    def test_list_templates_default_attrs(self):
+        with mock.patch("cterasdk.core.templates.query.iterator") as query_iterator_mock:
+            templates.Templates(self._global_admin).list_templates()
+            query_iterator_mock.assert_called_once_with(self._global_admin, '/deviceTemplates', mock.ANY)
+            expected_query_params = base_core.BaseCoreTest._create_query_params(include=templates.Templates.default,
+                                                                                start_from=0, count_limit=50)
+            actual_query_params = query_iterator_mock.call_args[0][2]
+            self._assert_equal_objects(actual_query_params, expected_query_params)
+
+    def test_delete_template(self):
+        delete_response = 'Success'
+        self._init_global_admin(delete_response=delete_response)
+        ret = templates.Templates(self._global_admin).delete(self._template)
+        self._global_admin.delete.assert_called_once_with('/deviceTemplates/' + self._template)
+        self.assertEqual(ret, delete_response)
+
+    def test_set_default_template_no_wait(self):
+        execute_response = 'Success'
+        self._init_global_admin(execute_response=execute_response)
+        ret = templates.Templates(self._global_admin).set_default(self._template)
+        self._global_admin.execute.assert_has_calls([
+            mock.call('/deviceTemplates/' + self._template, 'setAsDefault'),
+            mock.call('', 'applyAutoAssignmentRules')
+        ])
+        self.assertEqual(ret, execute_response)
+
+    def test_remove_default_template_no_wait(self):
+        execute_response = 'Success'
+        get_multi_response = self._get_template_object(name=self._template, isDefault=True)
+        self._init_global_admin(get_multi_response=get_multi_response, execute_response=execute_response)
+        ret = templates.Templates(self._global_admin).remove_default(self._template)
+        self._global_admin.get_multi.assert_called_once_with('/deviceTemplates/%s' % self._template, mock.ANY)
+        self._global_admin.execute.assert_has_calls([
+            mock.call('', 'removeDefaultDeviceTemplate'),
+            mock.call('', 'applyAutoAssignmentRules')
+        ])
+        self.assertEqual(ret, execute_response)
+
+    def _get_template_object(self, **kwargs):
+        template_object = Object()
+        template_object._classname = self._template_classname  # pylint: disable=protected-access
+        for key, value in kwargs.items():
+            setattr(template_object, key, value)
+        return template_object


### PR DESCRIPTION
1) Get, list, delete templates
2) Add templates (configure backup and exclude sets)
3) Set and remove default template
4) Trigger template auto assignment rule updates
5) Fix documentation typos
6) Add some unit tests
7) Move shared code to common types and enum