### PR TITLE
added DedupType parameters for FolderGroup options

### DIFF
--- a/cterasdk/core/cloudfs.py
+++ b/cterasdk/core/cloudfs.py
@@ -43,19 +43,23 @@ class CloudFS(BaseCommand):
         param = builder.build()
         return query.iterator(self._portal, '/foldersGroups', param)
 
-    def mkfg(self, name, user=None):
+    def mkfg(self, name, user=None, deduplication_method_type=None, fixed_block_size_kb=None):
         """
         Create a new Folder Group
 
         :param str name: Name of the new folder group
         :param cterasdk.core.types.UserAccount user:
          User account, the user directory and name of the new folder group owner (default to None)
+        :param str deduplication_method_type: Deduplication-Method = <"FixedBlockSize"> / <"averageBlockSizeKb">
+        :param int fixed_block_size_kb: Fixed Block Size KB = <16> - <16384>
         """
 
         param = Object()
         param.name = name
         param.disabled = True
         param.owner = self._portal.users.get(user, ['baseObjectRef']).baseObjectRef if user is not None else None
+        param.deduplicationMethodType = deduplication_method_type
+        param.fixedBlockSizeKb = fixed_block_size_kb
 
         try:
             response = self._portal.execute('', 'createFolderGroup', param)


### PR DESCRIPTION
added two parameters to CloudFS mkfg()
1. deduplication_method_type = str deduplication_method_type: Deduplication-Method = <"FixedBlockSize"> / <"averageBlockSizeKb">
2. fixed_block_size_kb = int fixed_block_size_kb: Fixed Block Size KB = <16> - <16384>

in order to support "FixedBlockSize" who is not the defualt Type.