### PR TITLE
Edge-Network-StaticRoutes-get/set/del/clean + UnitTests

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -28,7 +28,7 @@ limit-inference-results=100
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint.extensions.no_self_use
 
 # Pickle collected data for later comparisons.
 persistent=yes
@@ -60,16 +60,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=print-statement,
-        parameter-unpacking,
-        unpacking-in-except,
-        old-raise-syntax,
-        backtick,
-        long-suffix,
-        old-ne-operator,
-        old-octal-literal,
-        import-star-module-level,
-        non-ascii-bytes-literal,
+disable=
         raw-checker-failed,
         bad-inline-option,
         locally-disabled,
@@ -78,67 +69,6 @@ disable=print-statement,
         useless-suppression,
         deprecated-pragma,
         use-symbolic-message-instead,
-        apply-builtin,
-        basestring-builtin,
-        buffer-builtin,
-        cmp-builtin,
-        coerce-builtin,
-        execfile-builtin,
-        file-builtin,
-        long-builtin,
-        raw_input-builtin,
-        reduce-builtin,
-        standarderror-builtin,
-        unicode-builtin,
-        xrange-builtin,
-        coerce-method,
-        delslice-method,
-        getslice-method,
-        setslice-method,
-        no-absolute-import,
-        old-division,
-        dict-iter-method,
-        dict-view-method,
-        next-method-called,
-        metaclass-assignment,
-        indexing-exception,
-        raising-string,
-        reload-builtin,
-        oct-method,
-        hex-method,
-        nonzero-method,
-        cmp-method,
-        input-builtin,
-        round-builtin,
-        intern-builtin,
-        unichr-builtin,
-        map-builtin-not-iterating,
-        zip-builtin-not-iterating,
-        range-builtin-not-iterating,
-        filter-builtin-not-iterating,
-        using-cmp-argument,
-        eq-without-hash,
-        div-method,
-        idiv-method,
-        rdiv-method,
-        exception-message-attribute,
-        invalid-str-codec,
-        sys-max-int,
-        bad-python3-import,
-        deprecated-string-function,
-        deprecated-str-translate-call,
-        deprecated-itertools-function,
-        deprecated-types-field,
-        next-method-defined,
-        dict-items-not-iterating,
-        dict-keys-not-iterating,
-        dict-values-not-iterating,
-        deprecated-operator-function,
-        deprecated-urllib-function,
-        xreadlines-attribute,
-        deprecated-sys-function,
-        exception-escape,
-        comprehension-escape,
         missing-docstring,
         invalid-name,
         duplicate-code,
@@ -361,8 +291,8 @@ max-module-lines=1000
 # separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
 # `trailing-comma` allows a space between comma and closing bracket: (a, ).
 # `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
+#no-space-check=trailing-comma,
+#               dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.

--- a/cterasdk/common/__init__.py
+++ b/cterasdk/common/__init__.py
@@ -1,7 +1,7 @@
 from .item import Item  # noqa: E402, F401
 from .object import Object, Device, delete_attrs  # noqa: E402, F401
 from .datetime_utils import DateTimeUtils  # noqa: E402, F401
-from .utils import merge, union, parse_base_object_ref, convert_size, df_military_time, DataUnit  # noqa: E402, F401
+from .utils import merge, union, parse_base_object_ref, convert_size, df_military_time, DataUnit, parse_to_ipaddress  # noqa: E402, F401
 from .types import PolicyRule, PolicyRuleConverter, StringCriteriaBuilder, IntegerCriteriaBuilder, DateTimeCriteriaBuilder, \
                    ListCriteriaBuilder, ThrottlingRuleBuilder, ThrottlingRule, FilterBackupSet, FileFilterBuilder, \
                    ApplicationBackupSet, TimeRange  # noqa: E402, F401

--- a/cterasdk/common/utils.py
+++ b/cterasdk/common/utils.py
@@ -1,3 +1,4 @@
+import ipaddress
 import re
 import logging
 from datetime import datetime
@@ -144,3 +145,26 @@ def parse_base_object_ref(base_object_ref):
         return BaseObjectRef(classname, uid, tenant, name)
     logging.getLogger().debug('No match found. %s', {'ref': base_object_ref})
     return None
+
+
+def parse_to_ipaddress(address):
+    """
+    Parse an ip or network address into ipaddress object
+
+    :param str address: ip (10.0.0.5) or network address (192.168.44.0/28)
+    :return: ipaddress.IPV4Address/IPV6Address or ipaddress.IPV4Network/IPV6Network
+    """
+
+    try:
+        try:
+            ip_addrr = ipaddress.ip_address(address)
+            logging.getLogger().debug('ip address validated. %s', {'ip': str(ip_addrr)})
+            return ip_addrr
+        except (ValueError, TypeError):
+            ip_network = ipaddress.ip_network(address)
+            logging.getLogger().debug('ip network validated. %s', {'network': str(ip_network)})
+            return ip_network
+    except (ValueError, TypeError):
+        err = ValueError(f'{address} does not appear to be an IPv4 or IPv6 network or ip address')
+        logging.getLogger().error('Incorrect entry, please use IPv4 or IPv6 CIDR Formats. %s', {'Error': err})
+        raise err

--- a/docs/source/user_guides/Gateway/Gateway.rst
+++ b/docs/source/user_guides/Gateway/Gateway.rst
@@ -950,7 +950,7 @@ Network
 .. code-block:: python
 
    # get static routes
-   filer.network.get_static_route()
+   filer.network.get_static_routes()
 
 .. automethod:: cterasdk.edge.network.Network.add_static_route
    :noindex:
@@ -971,13 +971,13 @@ Network
    # remove static route 192.168.55.7/32
    filer.network.remove_static_route('192.168.55.7/32')
 
-.. automethod:: cterasdk.edge.network.Network.clean_static_routes
+.. automethod:: cterasdk.edge.network.Network.clean_all_static_routes
    :noindex:
 
 .. code-block:: python
 
    # remove all static routes -  (clean)
-   filer.network.clean_static_routes()
+   filer.network.clean_all_static_routes()
 
 
 Network Diagnostics

--- a/docs/source/user_guides/Gateway/Gateway.rst
+++ b/docs/source/user_guides/Gateway/Gateway.rst
@@ -944,6 +944,42 @@ Network
 
    filer.network.reset_mtu()  # disable custom mtu configuration and restore default setting (1500)
 
+.. automethod:: cterasdk.edge.network.Network.get_static_routes
+   :noindex:
+
+.. code-block:: python
+
+   # get static routes
+   filer.network.get_static_route()
+
+.. automethod:: cterasdk.edge.network.Network.add_static_route
+   :noindex:
+
+.. code-block:: python
+
+   # add static route from 10.10.12.1 to 192.168.55.7/32
+   filer.network.add_static_route('10.10.12.1', '192.168.55.7/32')
+
+   # add static route from 10.100.102.4 to 172.18.100.0/24
+   filer.network.add_static_route('10.100.102.4', '172.18.100.0/24')
+
+.. automethod:: cterasdk.edge.network.Network.remove_static_route
+   :noindex:
+
+.. code-block:: python
+
+   # remove static route 192.168.55.7/32
+   filer.network.remove_static_route('192.168.55.7/32')
+
+.. automethod:: cterasdk.edge.network.Network.clean_static_routes
+   :noindex:
+
+.. code-block:: python
+
+   # remove all static routes -  (clean)
+   filer.network.clean_static_routes()
+
+
 Network Diagnostics
 ^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ut/test_edge_network.py
+++ b/tests/ut/test_edge_network.py
@@ -5,10 +5,11 @@ from cterasdk.edge.types import TCPService, TCPConnectResult
 from cterasdk.lib import task_manager_base
 from cterasdk.edge.enum import Mode, IPProtocol, Traffic
 from cterasdk.common import Object
+from cterasdk import exception
 from tests.ut import base_edge
 
 
-class TestEdgeNetwork(base_edge.BaseEdgeTest):
+class TestEdgeNetwork(base_edge.BaseEdgeTest):  # pylint: disable=(too-many-public-methods
 
     def setUp(self):
         super().setUp()
@@ -35,6 +36,16 @@ class TestEdgeNetwork(base_edge.BaseEdgeTest):
         self._tcp_connect_port = 995
 
         self._mtu = 1320
+
+        self._static_route_1 = Object()
+        self._static_route_1.GwIP = '192.168.0.150'
+        self._static_route_1.DestIpMask = '172.64.28.15_32'
+        self._static_routes = []
+        self._static_routes.append(self._static_route_1)
+        self._static_route_2 = Object()
+        self._static_route_2.GwIP = '192.168.88.99'
+        self._static_route_2.DestIpMask = '10.64.28.15_32'
+        self._static_routes.append(self._static_route_2)
 
     def test_network_status(self):
         get_response = 'Success'
@@ -226,3 +237,76 @@ class TestEdgeNetwork(base_edge.BaseEdgeTest):
         tcp_connect_param.address = self._tcp_connect_address
         tcp_connect_param.port = self._tcp_connect_port
         return tcp_connect_param
+
+    def test_set_static_routes(self):
+        add_response = f'/config/network/static_routes/{self._static_routes[0].DestIpMask}'
+        self._init_filer(add_response=add_response)
+        network.Network(self._filer).set_static_route(
+            self._static_routes[0].GwIP,
+            self._static_routes[0].DestIpMask.split("_")[0],
+            self._static_routes[0].DestIpMask.split("_")[1]
+        )
+        self._filer.add.assert_called_once_with('/config/network/static_routes', mock.ANY)
+
+        expected_param = self._static_routes[0]
+        actual_param = self._filer.add.call_args[0][1]
+        self._assert_equal_objects(actual_param, expected_param)
+
+    def test_set_static_routes_raise(self):
+        expected_exception = exception.CTERAException()
+        self._filer.add = mock.MagicMock(side_effect=expected_exception)
+        with self.assertRaises(exception.CTERAException) as error:
+            network.Network(self._filer).set_static_route(
+                self._static_routes[0].GwIP,
+                self._static_routes[0].DestIpMask.split("_")[0],
+                self._static_routes[0].DestIpMask.split("_")[1]
+            )
+        self.assertEqual('Static route creation failed', error.exception.message)
+
+    def test_get_all_static_routes(self):
+        get_response = 'Success'
+        self._init_filer(get_response=get_response)
+        ret = network.Network(self._filer).get_static_routes()
+        self._filer.get.assert_called_once_with('/config/network/static_routes')
+        self.assertEqual(ret, get_response)
+
+    def test_delete_static_route(self):
+        self._init_filer(delete_response=self._static_routes[0])
+
+        ret = network.Network(self._filer).del_static_route(
+            self._static_routes[0].DestIpMask.split("_")[0],
+            self._static_routes[0].DestIpMask.split("_")[1])
+        self._filer.delete.assert_called_once_with(f'/config/network/static_routes/{self._static_routes[0].DestIpMask}')
+
+        self.assertEqual(self._static_routes[0], ret)
+
+    def test_delete_static_route_raise(self):
+        expected_exception = exception.CTERAException()
+        self._filer.delete = mock.MagicMock(side_effect=expected_exception)
+        with self.assertRaises(exception.CTERAException) as error:
+            network.Network(self._filer).del_static_route(
+                self._static_routes[0].DestIpMask.split("_")[0],
+                self._static_routes[0].DestIpMask.split("_")[1])
+        self.assertEqual('Static route deletion failed', error.exception.message)
+
+    def test_clean_all_static_routes_success(self):
+        expected_exception = 'Success'
+        self._init_filer(execute_response=expected_exception)
+        self._filer.execute = mock.MagicMock(side_effect=expected_exception)
+
+        ret = network.Network(self._filer).clean_all_static_routes()
+
+        expected_param = 'cleanStaticRoutes'
+        actual_param = self._filer.execute.call_args[0][1]
+        self._assert_equal_objects(actual_param, expected_param)
+
+        self.assertEqual(ret, 'All Static Routes cleaned Successfully')
+
+    def test_clean_all_static_routes_raise(self):
+        expected_exception = exception.CTERAException()
+        self._init_filer(execute_response=expected_exception)
+        self._filer.execute = mock.MagicMock(side_effect=expected_exception)
+
+        with self.assertRaises(exception.CTERAException) as error:
+            network.Network(self._filer).clean_all_static_routes()
+        self.assertEqual('Failed to clean Static routes', error.exception.message)

--- a/tests/ut/test_edge_network.py
+++ b/tests/ut/test_edge_network.py
@@ -9,7 +9,7 @@ from cterasdk import exception
 from tests.ut import base_edge
 
 
-class TestEdgeNetwork(base_edge.BaseEdgeTest):  # pylint: disable=(too-many-public-methods
+class TestEdgeNetwork(base_edge.BaseEdgeTest):  # pylint: disable=too-many-public-methods
 
     def setUp(self):
         super().setUp()

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     -r{toxinidir}/docs/requirements.txt
     -r{toxinidir}/ut-requirements.txt
     flake8 >= 3.7.9
-    pylint >= 2.10.2,<=2.13.9
+    pylint >= 2.10.2
     doc8
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     -r{toxinidir}/docs/requirements.txt
     -r{toxinidir}/ut-requirements.txt
     flake8 >= 3.7.9
-    pylint >= 2.10.2
+    pylint >= 2.10.2,<=2.13.9
     doc8
 
 commands =


### PR DESCRIPTION
**cterask.edge.netwok.py:**
Network.get_static_routes
Network.set_static_route
Network.del_static_route
Network.clean_all_static_routes

UnitTests
**cterasdk.tests.ut.test_edge_network.py:**
TestEdgeNetwork.test_set_static_routes
TestEdgeNetwork.test_set_static_routes_raise
TestEdgeNetwork.test_get_all_static_routes
TestEdgeNetwork.test_delete_static_route
TestEdgeNetwork.test_delete_static_route_raise
TestEdgeNetwork.test_clean_all_static_routes_success
TestEdgeNetwork.test_clean_all_static_routes_raise