### PR TITLE
Improve handling of empty responses

### DIFF
--- a/cterasdk/core/portals.py
+++ b/cterasdk/core/portals.py
@@ -23,7 +23,7 @@ class Portals(BaseCommand):
         include = union(include or [], Portals.default)
         include = ['/' + attr for attr in include]
         tenant = self._core.api.get_multi('/portals/' + name, include)
-        if tenant.name is None:
+        if tenant is None or tenant.name is None:
             raise ObjectNotFoundException('Could not find tenant', f'/portals/{name}', name=name)
         return tenant
 

--- a/cterasdk/edge/services.py
+++ b/cterasdk/edge/services.py
@@ -31,7 +31,7 @@ class Services(BaseCommand):
         """
         status = self._edge.api.get('/status/services')
         connection = Object()
-        connection.connected = status.CTERAPortal.connectionState == enum.ServicesConnectionState.Connected
+        connection.connected = status and status.CTERAPortal.connectionState == enum.ServicesConnectionState.Connected
         if connection.connected:
             connection.ipaddr = status.CTERAPortal.connectedAddress
             connection.user = status.userDisplayName

--- a/cterasdk/lib/iterator.py
+++ b/cterasdk/lib/iterator.py
@@ -31,7 +31,7 @@ class BaseIterator:
 
     @abstractmethod
     def page(self):
-        raise NotImplementedError("Subclass must implemenet the 'page' function")
+        raise NotImplementedError("Subclass must implement the 'page' function")
 
 
 class KeyValueQueryIterator(BaseIterator):


### PR DESCRIPTION
- Services.get_status(): explicitly check for truthy response
- Portals.get(): explicitly check for non-None response
- Minor spell check fix

----

Example exceptions corrected by this PR:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/gqal/CTERA/venv39/lib64/python3.9/site-packages/cterasdk/core/portals.py", line 26, in get
    if tenant.name is None:
AttributeError: 'NoneType' object has no attribute 'name'
```

```
Traceback (most recent call last):
  File "/opt/splunk/etc/apps/TA-CTERA-CloudStorageGateway/bin/../lib/cterasdk/edge/services.py", line 34, in get_status
    connection.connected = status.CTERAPortal.connectionState == enum.ServicesConnectionState.Connected
AttributeError: 'NoneType' object has no attribute 'CTERAPortal'
```