### PR TITLE
Ronerez/snapshots support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ ChangeLog
 .coverage
 .venv
 .cursorrules
+.DS_Store

--- a/cterasdk/core/files/browser.py
+++ b/cterasdk/core/files/browser.py
@@ -82,6 +82,21 @@ class FileBrowser(BaseCommand):
     def base(self):
         return self._base
 
+    def list_snapshots(self, path):
+        """
+        List snapshots of a file or directory
+
+        :param str path: Path to the file or directory
+        :return: List of snapshots, each containing:
+                - startTimestamp: When the snapshot was created
+                - calculatedTimestamp: When the snapshot was processed
+                - current: Whether this is the current version
+                - url: The URL path to access this snapshot's contents
+        :rtype: list[dict]
+        """
+        param = self.get_object_path(path).fullpath()
+        return self._core.api.execute('', 'listSnapshots', param)
+
 
 class CloudDrive(FileBrowser):
 

--- a/cterasdk/core/files/common.py
+++ b/cterasdk/core/files/common.py
@@ -109,6 +109,15 @@ class FetchResourcesParamBuilder:
 
     def include_deleted(self):
         self.param.includeDeleted = True  # pylint: disable=attribute-defined-outside-init
+        return self
+
+    def for_previous_versions(self):
+        """Add parameters needed for accessing PreviousVersions directories"""
+        self.param.includeDeleted = False  # pylint: disable=attribute-defined-outside-init
+        self.param.cloudFolderType = ['Personal']  # pylint: disable=attribute-defined-outside-init
+        self.param.sharedItems = False  # pylint: disable=attribute-defined-outside-init
+        self.param.sort = [{'_classname': 'Sort', 'field': 'name', 'ascending': True}]  # pylint: disable=attribute-defined-outside-init
+        return self
 
     def build(self):
         return self.param
@@ -163,6 +172,10 @@ class Path:
         return str(self._base.joinpath(self._relative))
 
     def encoded_fullpath(self):
+        path = str(self._relative)
+        if 'PreviousVersions/' in path:
+            idx = path.index('PreviousVersions/') + len('PreviousVersions/')
+            return str(self._base) + '/' + uri.quote(path[:idx]) + path[idx:]
         return uri.quote(self.fullpath())
 
     def encoded_parent(self):

--- a/cterasdk/core/files/io.py
+++ b/cterasdk/core/files/io.py
@@ -7,6 +7,8 @@ def listdir(core, path, depth=None, include_deleted=False):
     builder = common.FetchResourcesParamBuilder().root(path.encoded_fullpath()).depth(depth)
     if include_deleted:
         builder.include_deleted()
+    elif 'PreviousVersions/' in str(path):
+        builder.for_previous_versions()
     param = builder.build()
     if depth > 0:
         return common.objects_iterator(core, param)

--- a/docs/source/UserGuides/Portal/Files.rst
+++ b/docs/source/UserGuides/Portal/Files.rst
@@ -35,6 +35,24 @@ List
       for element in user.files.walk('My Files/Documents'):
          print(element.name)  # as a user, traverse all and print the name of all files and folders in 'My Files/Documents'
 
+Snapshots
+=========
+
+.. automethod:: cterasdk.core.files.browser.FileBrowser.list_snapshots
+   :noindex:
+
+.. code:: python
+
+   with GlobalAdmin('tenant.ctera.com') as admin:
+      admin.login('admin-user', 'admin-pass')
+      # List all snapshots for a path
+      snapshots = admin.files.list_snapshots('Users/John Smith/My Files')
+      for snapshot in snapshots:
+         print(f"Snapshot from: {snapshot.startTimestamp}")
+         print(f"URL: {snapshot.url}")
+         # Access files in this snapshot using listdir
+         files = admin.files.listdir(f"{snapshot.url}")
+
 Download
 ========
 

--- a/tests/ut/test_core_files_browser.py
+++ b/tests/ut/test_core_files_browser.py
@@ -12,6 +12,12 @@ class TestCoreFilesBrowser(base_core.BaseCoreTest):
         super().setUp()
         self.files = CloudDrive(self._global_admin)
 
+    def test_list_snapshots(self):
+        path = 'cloud/Users'
+        self._global_admin.api.execute = mock.MagicMock()
+        self.files.list_snapshots(path)
+        self._global_admin.api.execute.assert_called_once_with('', 'listSnapshots', os.path.join(TestCoreFilesBrowser._base_path, path))
+
     def test_listdir(self):
         path = 'cloud/Users'
         listdir_mock = self.patch_call('cterasdk.core.files.io.listdir')


### PR DESCRIPTION
Added support for listing and accessing file/folder snapshots in CTERA Portal.
Users can now list available snapshots for a path and access files within those snapshots using listdir and copy operations.