### PR TITLE
Sudo Role Fix

### DIFF
--- a/cterasdk/core/roles.py
+++ b/cterasdk/core/roles.py
@@ -48,8 +48,11 @@ class Roles(BaseCommand):
         :returns: Updated role settings
         :rtype: cterasdk.core.types.RoleSettings
         """
+        name = role
         role = Roles.find(role)
         if role:
+            if settings.sudo:
+                settings = RoleSettings(name=name, **{attr: True for attr in settings.__dict__.keys() if attr != 'name'})
             logging.getLogger('cterasdk.core').info('Updating role settings. %s', {'role': role})
             response = self._core.api.put(f'/rolesSettings/{role}', settings.to_server_object())
             logging.getLogger('cterasdk.core').info('Role settings updated. %s', {'role': role})

--- a/cterasdk/core/types.py
+++ b/cterasdk/core/types.py
@@ -750,11 +750,14 @@ class RoleSettings(Object):  # pylint: disable=too-many-instance-attributes
     :ivar bool manage_cloud_drives: Manage Cloud Folders
     :ivar bool manage_plans: Manage Plans
     :ivar bool manage_logs: Manage Log Settings
+    :ivar bool allow_folders_files_permanent_delete: Allow Folders Files Permanent Delete
+    :ivar bool can_manage_legal_holds: Manage Legal Holds
+    :ivar bool can_manage_compliance_settings: Manage Compliance Settings
     """
     # pylint: disable=too-many-arguments, too-many-locals
     def __init__(self, name, sudo, enable_remote_wipe, enable_sso, enable_seeding_export, enable_seeding_import, access_end_user_folders,
                  update_settings, update_roles, update_account_emails, update_account_password, manage_cloud_drives, manage_plans,
-                 manage_users, manage_logs):
+                 manage_users, manage_logs, allow_folders_files_permanent_delete, can_manage_legal_holds, can_manage_compliance_settings):
         self.name = name
         self.sudo = sudo
         self.enable_remote_wipe = enable_remote_wipe
@@ -770,6 +773,9 @@ class RoleSettings(Object):  # pylint: disable=too-many-instance-attributes
         self.manage_plans = manage_plans
         self.manage_users = manage_users
         self.manage_logs = manage_logs
+        self.allow_folders_files_permanent_delete = allow_folders_files_permanent_delete
+        self.can_manage_legal_holds = can_manage_legal_holds
+        self.can_manage_compliance_settings = can_manage_compliance_settings
 
     def to_server_object(self):
         param = Object()
@@ -789,6 +795,9 @@ class RoleSettings(Object):  # pylint: disable=too-many-instance-attributes
         param.canManagePlans = self.manage_plans
         param.canManageUsers = self.manage_users
         param.canManageLogSettings = self.manage_logs
+        param.allowFoldersFilesPermanentDelete = self.allow_folders_files_permanent_delete
+        param.canManageLegalHolds = self.can_manage_legal_holds
+        param.canManageComplianceSetting = self.can_manage_compliance_settings
         return param
 
     @staticmethod
@@ -808,6 +817,9 @@ class RoleSettings(Object):  # pylint: disable=too-many-instance-attributes
             'manage_cloud_drives': server_object.canManageAllFolders,
             'manage_plans': server_object.canManagePlans,
             'manage_users': server_object.canManageUsers,
-            'manage_logs': server_object.canManageLogSettings
+            'manage_logs': server_object.canManageLogSettings,
+            'allow_folders_files_permanent_delete': server_object.allowFoldersFilesPermanentDelete,
+            'can_manage_legal_holds': server_object.canManageLegalHolds,
+            'can_manage_compliance_settings': server_object.canManageComplianceSetting
         }
         return RoleSettings(**params)

--- a/tests/ut/core/admin/test_roles.py
+++ b/tests/ut/core/admin/test_roles.py
@@ -59,5 +59,8 @@ class TestCoreRoles(base_admin.BaseCoreTest):
             'canManageAllFolders': True,
             'canManagePlans': True,
             'canManageUsers': True,
-            'canManageLogSettings': False
+            'canManageLogSettings': False,
+            'allowFoldersFilesPermanentDelete': False,
+            'canManageLegalHolds': False,
+            'canManageComplianceSetting': False
         })


### PR DESCRIPTION
feat: add new role settings with test support

Added new role settings to RoleSettings class:
- allowFoldersFilesPermanentDelete: Control permanent file/folder deletion
- canManageLegalHolds: Control legal hold management permissions
- canManageComplianceSetting: Control compliance settings management

Updated corresponding test cases to include the new settings.