### PR TITLE
Fix whitespace in SNMP docstring

### DIFF
--- a/cterasdk/edge/snmp.py
+++ b/cterasdk/edge/snmp.py
@@ -56,7 +56,7 @@ class SNMP(BaseCommand):
     def get_configuration(self):
         """
         Get current SNMP configuration
-        
+
         :return: Current SNMP configuration
         :rtype: cterasdk.common.object.Object
         """


### PR DESCRIPTION
Remove trailing whitespace to resolve flake8 W293 warning