### PR TITLE
Add tests and simplify permission handling logic

### DIFF
--- a/cterasdk/asynchronous/core/files/browser.py
+++ b/cterasdk/asynchronous/core/files/browser.py
@@ -194,8 +194,7 @@ class CloudDrive(FileBrowser):
             destination,
             handle,
             name,
-            size,
-            
+            size
         ).a_execute()
 
     async def upload_file(self, path, destination):
@@ -214,8 +213,7 @@ class CloudDrive(FileBrowser):
                 destination,
                 handle,
                 name,
-                commonfs.properties(path)['size'],
-                
+                commonfs.properties(path)['size']
             )
 
     async def mkdir(self, path):
@@ -258,8 +256,7 @@ class CloudDrive(FileBrowser):
             wait,
             path,
             name,
-            resolver,
-            
+            resolver
         ).a_execute()
 
     async def delete(self, *paths, wait=False):

--- a/cterasdk/asynchronous/core/files/browser.py
+++ b/cterasdk/asynchronous/core/files/browser.py
@@ -142,7 +142,7 @@ class FileBrowser(BaseCommand):
         """
         return await Link(io.public_link, self._core, path, access, expire_in).a_execute()
 
-    async def copy(self, *paths, destination=None, resolver=None, cursor=None, wait=False, strict_permission=False):
+    async def copy(self, *paths, destination=None, resolver=None, cursor=None, wait=False):
         """
         Copy one or more files or folders.
 
@@ -156,16 +156,7 @@ class FileBrowser(BaseCommand):
         :raises cterasdk.exceptions.io.core.CopyError: Raised on failure copying resources.
         """
         try:
-            return await Copy(
-                io.copy,
-                self._core,
-                wait,
-                *paths,
-                destination=destination,
-                resolver=resolver,
-                cursor=cursor,
-                strict_permission=strict_permission
-            ).a_execute()
+            return await Copy(io.copy, self._core, wait, *paths, destination=destination, resolver=resolver, cursor=cursor).a_execute()
         except ValueError:
             raise ValueError('Copy destination was not specified.')
 
@@ -184,7 +175,7 @@ class FileBrowser(BaseCommand):
 class CloudDrive(FileBrowser):
     """Async CloudDrive API with upload and sharing functionality."""
 
-    async def upload(self, destination, handle, name=None, size=None, strict_permission=False):
+    async def upload(self, destination, handle, name=None, size=None):
         """
         Upload from file handle.
 
@@ -204,10 +195,10 @@ class CloudDrive(FileBrowser):
             handle,
             name,
             size,
-            strict_permission=strict_permission
+            
         ).a_execute()
 
-    async def upload_file(self, path, destination, strict_permission=False):
+    async def upload_file(self, path, destination):
         """
         Upload a file.
 
@@ -224,10 +215,10 @@ class CloudDrive(FileBrowser):
                 handle,
                 name,
                 commonfs.properties(path)['size'],
-                strict_permission=strict_permission
+                
             )
 
-    async def mkdir(self, path, strict_permission=False):
+    async def mkdir(self, path):
         """
         Create a directory.
 
@@ -236,9 +227,9 @@ class CloudDrive(FileBrowser):
         :rtype: str
         :raises cterasdk.exceptions.io.core.CreateDirectoryError: Raised on error creating directory.
         """
-        return await CreateDirectory(io.mkdir, self._core, path, strict_permission=strict_permission).a_execute()
+        return await CreateDirectory(io.mkdir, self._core, path, ).a_execute()
 
-    async def makedirs(self, path, strict_permission=False):
+    async def makedirs(self, path):
         """
         Recursively create a directory.
 
@@ -247,9 +238,9 @@ class CloudDrive(FileBrowser):
         :rtype: str
         :raises cterasdk.exceptions.io.core.CreateDirectoryError: Raised on error creating directory.
         """
-        return await CreateDirectory(io.mkdir, self._core, path, True, strict_permission=strict_permission).a_execute()
+        return await CreateDirectory(io.mkdir, self._core, path, True, ).a_execute()
 
-    async def rename(self, path, name, *, resolver=None, wait=False, strict_permission=False):
+    async def rename(self, path, name, *, resolver=None, wait=False):
         """
         Rename a file or folder.
 
@@ -268,10 +259,10 @@ class CloudDrive(FileBrowser):
             path,
             name,
             resolver,
-            strict_permission=strict_permission
+            
         ).a_execute()
 
-    async def delete(self, *paths, wait=False, strict_permission=False):
+    async def delete(self, *paths, wait=False):
         """
         Delete one or more files or folders.
 
@@ -281,7 +272,7 @@ class CloudDrive(FileBrowser):
         :rtype: cterasdk.common.object.Object or :class:`cterasdk.lib.tasks.AwaitablePortalTask`
         :raises cterasdk.exceptions.io.core.DeleteError: Raised on error deleting resources.
         """
-        return await Delete(io.delete, self._core, wait, *paths, strict_permission=strict_permission).a_execute()
+        return await Delete(io.delete, self._core, wait, *paths, ).a_execute()
 
     async def undelete(self, *paths, wait=False):
         """
@@ -295,7 +286,7 @@ class CloudDrive(FileBrowser):
         """
         return await Recover(io.undelete, self._core, wait, *paths).a_execute()
 
-    async def move(self, *paths, destination=None, resolver=None, cursor=None, wait=False, strict_permission=False):
+    async def move(self, *paths, destination=None, resolver=None, cursor=None, wait=False):
         """
         Move one or more files or folders.
 
@@ -309,16 +300,7 @@ class CloudDrive(FileBrowser):
         :raises cterasdk.exceptions.io.core.MoveError: Raised on error moving resources.
         """
         try:
-            return await Move(
-                io.move,
-                self._core,
-                wait,
-                *paths,
-                destination=destination,
-                resolver=resolver,
-                cursor=cursor,
-                strict_permission=strict_permission
-            ).a_execute()
+            return await Move(io.move, self._core, wait, *paths, destination=destination, resolver=resolver, cursor=cursor).a_execute()
         except ValueError:
             raise ValueError('Move destination was not specified.')
 

--- a/cterasdk/asynchronous/core/roles.py
+++ b/cterasdk/asynchronous/core/roles.py
@@ -1,0 +1,36 @@
+import logging
+
+from ...core.enum import RoleResolver
+from ...core.types import RoleSettings
+from .base_command import BaseCommand
+
+
+logger = logging.getLogger('cterasdk.core')
+
+
+class Roles(BaseCommand):
+    """
+    Role Settings APIs
+    """
+
+    @staticmethod
+    def find(role):
+        """
+        Find Role
+        """
+        options = {k: v for k, v in RoleResolver.__dict__.items() if not k.startswith('_')}
+        return options.get(role, None)
+
+    async def get(self, role):
+        """
+        Get Role
+
+        :param str role: Role
+        :returns: Role settings
+        :rtype: cterasdk.core.types.RoleSettings
+        """
+        name = Roles.find(role)
+        if name:
+            return RoleSettings.from_server_object(await self._core.v1.api.get(f'/rolesSettings/{name}'))
+        logger.warning('Could not find role. %s', {'role': role})
+        return None

--- a/cterasdk/cio/common.py
+++ b/cterasdk/cio/common.py
@@ -100,11 +100,10 @@ class BasePath:
 
     def __getitem__(self, key):
         if isinstance(key, slice):
-            return self.__class__(self.parts[key])
-        elif isinstance(key, int):
+            return self.__class__(self.parts[key])  # pylint: disable=no-value-for-parameter
+        if isinstance(key, int):
             return self.parts[key]
-        else:
-            raise TypeError("Invalid argument type")
+        raise TypeError("Invalid argument type")
 
     def __eq__(self, p):
         return self.absolute == p.absolute

--- a/cterasdk/cio/core/commands.py
+++ b/cterasdk/cio/core/commands.py
@@ -685,17 +685,7 @@ class CreateDirectory(PortalCommand):
     def _parents_generator(self):
         if self.parents:
             parts = self.path.parts
-            start_index = 1
-            known_roots = ('My Files', 'Shared With Me', 'Shared', 'Team Portal')
-            if parts:
-                if parts[0] in known_roots:
-                    start_index = 2
-                elif parts[0] in ('Users', 'Groups') and len(parts) > 1:
-                    if len(parts) > 2 and parts[2] in known_roots:
-                        start_index = 4
-                    else:
-                        start_index = 3
-            for i in range(start_index, len(parts)):
+            for i in range(1, len(parts)):
                 yield automatic_resolution('/'.join(parts[:i]), self._receiver.context)
         else:
             yield self.path
@@ -707,8 +697,7 @@ class CreateDirectory(PortalCommand):
                     CreateDirectory(
                         self._function,
                         self._receiver,
-                        path,
-                        strict_permission=self._strict_permission
+                        path
                     ).execute()
                 except exceptions.io.core.CreateDirectoryError as e:
                     CreateDirectory._suppress_file_conflict_error(e)
@@ -722,8 +711,7 @@ class CreateDirectory(PortalCommand):
                     await CreateDirectory(
                         self._function,
                         self._receiver,
-                        path,
-                        strict_permission=self._strict_permission
+                        path
                     ).a_execute()
                 except exceptions.io.core.CreateDirectoryError as e:
                     CreateDirectory._suppress_file_conflict_error(e)
@@ -1042,9 +1030,6 @@ class TaskCommand(PortalCommand):
 
         if r.completed:
             return self._task_complete(r)
-
-        if r.completed_with_warnings:
-            return r
 
         if r.failed or r.completed_with_warnings:
             return self._task_error(r)

--- a/cterasdk/cio/core/commands.py
+++ b/cterasdk/cio/core/commands.py
@@ -7,7 +7,7 @@ from abc import abstractmethod
 from contextlib import contextmanager
 from ...common import Object, DateTimeUtils
 from ...core.enum import ProtectionLevel, CollaboratorType, SearchType, PortalAccountType, FileAccessMode, \
-    UploadError, ResourceScope, ResourceError, Context, Role, Administrators
+    UploadError, ResourceScope, ResourceError, Context, Administrators
 from ...core.types import PortalAccount, UserAccount, GroupAccount, Collaborator
 from ... import exceptions
 from ...lib.storage import synfs, asynfs, commonfs

--- a/cterasdk/core/enum.py
+++ b/cterasdk/core/enum.py
@@ -68,17 +68,21 @@ class Role:
     """
     Portal User Role
 
-    :ivar str Disabled: Disabled user role
-    :ivar str EndUser: EndUser user role
-    :ivar str ReadWriteAdmin: ReadWriteAdmin user role
-    :ivar str ReadOnlyAdmin: ReadOnlyAdmin user role
-    :ivar str Support: Support user role
+    :ivar str Disabled: Disabled
+    :ivar str EndUser: End User
+    :ivar str ReadWriteAdmin: Read Write Administrator
+    :ivar str ReadOnlyAdmin: Read Only Administrator
+    :ivar str Support: Support Administrator
     """
     Disabled = "Disabled"
     EndUser = "EndUser"
     ReadWriteAdmin = "ReadWriteAdmin"
     ReadOnlyAdmin = "ReadOnlyAdmin"
+    ComplianceOfficer = "ComplianceOffer"
     Support = "Support"
+
+
+Administrators = [Role.ReadWriteAdmin, Role.ReadOnlyAdmin, Role.ComplianceOfficer, Role.Support]
 
 
 class RoleResolver:

--- a/cterasdk/core/files/browser.py
+++ b/cterasdk/core/files/browser.py
@@ -187,8 +187,7 @@ class CloudDrive(FileBrowser):
         :rtype: str
         :raises cterasdk.exceptions.io.core.UploadError: Raised on upload failure.
         """
-        return Upload(io.upload, self._core, io.listdir, destination, handle, name, size
-        ).execute()
+        return Upload(io.upload, self._core, io.listdir, destination, handle, name, size).execute()
 
     def upload_file(self, path, destination):
         """

--- a/cterasdk/core/files/browser.py
+++ b/cterasdk/core/files/browser.py
@@ -142,7 +142,7 @@ class FileBrowser(BaseCommand):
         """
         return Link(io.public_link, self._core, path, access, expire_in).execute()
 
-    def copy(self, *paths, destination=None, resolver=None, cursor=None, wait=True, strict_permission=False):
+    def copy(self, *paths, destination=None, resolver=None, cursor=None, wait=True):
         """
         Copy one or more files or folders.
 
@@ -156,16 +156,7 @@ class FileBrowser(BaseCommand):
         :raises cterasdk.exceptions.io.core.CopyError: Raised on failure to copy resources.
         """
         try:
-            return Copy(
-                io.copy,
-                self._core,
-                wait,
-                *paths,
-                destination=destination,
-                resolver=resolver,
-                cursor=cursor,
-                strict_permission=strict_permission
-            ).execute()
+            return Copy(io.copy, self._core, wait, *paths, destination=destination, resolver=resolver, cursor=cursor).execute()
         except ValueError:
             raise ValueError('Copy destination was not specified.')
 
@@ -184,7 +175,7 @@ class FileBrowser(BaseCommand):
 class CloudDrive(FileBrowser):
     """CloudDrive extends FileBrowser with upload and share functionality."""
 
-    def upload(self, destination, handle, name=None, size=None, strict_permission=False):
+    def upload(self, destination, handle, name=None, size=None):
         """
         Upload from file handle.
 
@@ -196,18 +187,10 @@ class CloudDrive(FileBrowser):
         :rtype: str
         :raises cterasdk.exceptions.io.core.UploadError: Raised on upload failure.
         """
-        return Upload(
-            io.upload,
-            self._core,
-            io.listdir,
-            destination,
-            handle,
-            name,
-            size,
-            strict_permission=strict_permission
+        return Upload(io.upload, self._core, io.listdir, destination, handle, name, size
         ).execute()
 
-    def upload_file(self, path, destination, strict_permission=False):
+    def upload_file(self, path, destination):
         """
         Upload a file.
 
@@ -219,15 +202,9 @@ class CloudDrive(FileBrowser):
         """
         _, name = commonfs.split_file_directory(path)
         with open(path, 'rb') as handle:
-            return self.upload(
-                destination,
-                handle,
-                name,
-                commonfs.properties(path)['size'],
-                strict_permission=strict_permission
-            )
+            return self.upload(destination, handle, name, commonfs.properties(path)['size'])
 
-    def mkdir(self, path, strict_permission=False):
+    def mkdir(self, path):
         """
         Create a directory.
 
@@ -236,9 +213,9 @@ class CloudDrive(FileBrowser):
         :rtype: str
         :raises cterasdk.exceptions.io.core.CreateDirectoryError: Raised on error creating directory.
         """
-        return CreateDirectory(io.mkdir, self._core, path, strict_permission=strict_permission).execute()
+        return CreateDirectory(io.mkdir, self._core, path).execute()
 
-    def makedirs(self, path, strict_permission=False):
+    def makedirs(self, path):
         """
         Recursively create a directory.
 
@@ -247,9 +224,9 @@ class CloudDrive(FileBrowser):
         :rtype: str
         :raises cterasdk.exceptions.io.core.CreateDirectoryError: Raised on error creating directory.
         """
-        return CreateDirectory(io.mkdir, self._core, path, True, strict_permission=strict_permission).execute()
+        return CreateDirectory(io.mkdir, self._core, path, True).execute()
 
-    def rename(self, path, name, *, resolver=None, wait=True, strict_permission=False):
+    def rename(self, path, name, *, resolver=None, wait=True):
         """
         Rename a file or folder.
 
@@ -261,17 +238,9 @@ class CloudDrive(FileBrowser):
         :rtype: cterasdk.common.object.Object or :class:`cterasdk.lib.tasks.AwaitablePortalTask`
         :raises cterasdk.exceptions.io.core.RenameError: Raised on error renaming object.
         """
-        return Rename(
-            io.move,
-            self._core,
-            wait,
-            path,
-            name,
-            resolver,
-            strict_permission=strict_permission
-        ).execute()
+        return Rename(io.move, self._core, wait, path, name, resolver).execute()
 
-    def delete(self, *paths, wait=True, strict_permission=False):
+    def delete(self, *paths, wait=True):
         """
         Delete one or more files or folders.
 
@@ -281,7 +250,7 @@ class CloudDrive(FileBrowser):
         :rtype: cterasdk.common.object.Object or :class:`cterasdk.lib.tasks.AwaitablePortalTask`
         :raises cterasdk.exceptions.io.core.DeleteError: Raised on error deleting resources.
         """
-        return Delete(io.delete, self._core, wait, *paths, strict_permission=strict_permission).execute()
+        return Delete(io.delete, self._core, wait, *paths).execute()
 
     def undelete(self, *paths, wait=True):
         """
@@ -295,7 +264,7 @@ class CloudDrive(FileBrowser):
         """
         return Recover(io.undelete, self._core, wait, *paths).execute()
 
-    def move(self, *paths, destination=None, resolver=None, cursor=None, wait=True, strict_permission=False):
+    def move(self, *paths, destination=None, resolver=None, cursor=None, wait=True):
         """
         Move one or more files or folders.
 
@@ -309,16 +278,7 @@ class CloudDrive(FileBrowser):
         :raises cterasdk.exceptions.io.core.MoveError: Raised on error moving resources.
         """
         try:
-            return Move(
-                io.move,
-                self._core,
-                wait,
-                *paths,
-                destination=destination,
-                resolver=resolver,
-                cursor=cursor,
-                strict_permission=strict_permission
-            ).execute()
+            return Move(io.move, self._core, wait, *paths, destination=destination, resolver=resolver, cursor=cursor).execute()
         except ValueError:
             raise ValueError('Move destination was not specified.')
 

--- a/cterasdk/core/roles.py
+++ b/cterasdk/core/roles.py
@@ -36,9 +36,9 @@ class Roles(BaseCommand):
         :returns: Role settings
         :rtype: cterasdk.core.types.RoleSettings
         """
-        role = Roles.find(role)
-        if role:
-            return RoleSettings.from_server_object(self._core.api.get(f'/rolesSettings/{role}'))
+        name = Roles.find(role)
+        if name:
+            return RoleSettings.from_server_object(self._core.api.get(f'/rolesSettings/{name}'))
         logger.warning('Could not find role. %s', {'role': role})
         return None
 

--- a/cterasdk/core/types.py
+++ b/cterasdk/core/types.py
@@ -778,14 +778,14 @@ class RoleSettings(Object):  # pylint: disable=too-many-instance-attributes
     :ivar bool manage_cloud_drives: Manage Cloud Folders
     :ivar bool manage_plans: Manage Plans
     :ivar bool manage_logs: Manage Log Settings
-    :ivar bool allow_folders_files_permanent_delete: Allow Folders Files Permanent Delete
-    :ivar bool can_manage_legal_holds: Manage Legal Holds
-    :ivar bool can_manage_compliance_settings: Manage Compliance Settings
+    :ivar bool permanent_delete: Allow Permanent Delete
+    :ivar bool manage_legal_holds: Manage Legal Holds
+    :ivar bool manage_compliance_settings: Manage Compliance Settings
     """
     # pylint: disable=too-many-arguments, too-many-locals
     def __init__(self, name, sudo, enable_remote_wipe, enable_sso, enable_seeding_export, enable_seeding_import, access_end_user_folders,
                  update_settings, update_roles, update_account_emails, update_account_password, manage_cloud_drives, manage_plans,
-                 manage_users, manage_logs, allow_folders_files_permanent_delete, can_manage_legal_holds, can_manage_compliance_settings):
+                 manage_users, manage_logs, permanent_delete, manage_legal_holds, manage_compliance_settings):
         super().__init__()
         self.name = name
         self.sudo = sudo
@@ -802,9 +802,9 @@ class RoleSettings(Object):  # pylint: disable=too-many-instance-attributes
         self.manage_plans = manage_plans
         self.manage_users = manage_users
         self.manage_logs = manage_logs
-        self.allow_folders_files_permanent_delete = allow_folders_files_permanent_delete
-        self.can_manage_legal_holds = can_manage_legal_holds
-        self.can_manage_compliance_settings = can_manage_compliance_settings
+        self.permanent_delete = permanent_delete
+        self.manage_legal_holds = manage_legal_holds
+        self.manage_compliance_settings = manage_compliance_settings
 
     def to_server_object(self):
         param = Object()
@@ -824,9 +824,9 @@ class RoleSettings(Object):  # pylint: disable=too-many-instance-attributes
         param.canManagePlans = self.manage_plans
         param.canManageUsers = self.manage_users
         param.canManageLogSettings = self.manage_logs
-        param.allowFoldersFilesPermanentDelete = self.allow_folders_files_permanent_delete
-        param.canManageLegalHolds = self.can_manage_legal_holds
-        param.canManageComplianceSetting = self.can_manage_compliance_settings
+        param.allowFoldersFilesPermanentDelete = self.permanent_delete
+        param.canManageLegalHolds = self.manage_legal_holds
+        param.canManageComplianceSetting = self.manage_compliance_settings
         return param
 
     @staticmethod
@@ -847,9 +847,9 @@ class RoleSettings(Object):  # pylint: disable=too-many-instance-attributes
             'manage_plans': server_object.canManagePlans,
             'manage_users': server_object.canManageUsers,
             'manage_logs': server_object.canManageLogSettings,
-            'allow_folders_files_permanent_delete': server_object.allowFoldersFilesPermanentDelete,
-            'can_manage_legal_holds': server_object.canManageLegalHolds,
-            'can_manage_compliance_settings': server_object.canManageComplianceSetting
+            'permanent_delete': server_object.allowFoldersFilesPermanentDelete,
+            'manage_legal_holds': server_object.canManageLegalHolds,
+            'manage_compliance_settings': server_object.canManageComplianceSetting
         }
         return RoleSettings(**params)
 

--- a/cterasdk/exceptions/io/core.py
+++ b/cterasdk/exceptions/io/core.py
@@ -56,6 +56,12 @@ class PrivilegeError(PathError):
         super().__init__(errno.EACCES, 'Access denied. No permission to access resource', filename)
 
 
+class ContextError(PathError):
+
+    def __init__(self, filename):
+        super().__init__(EREMOTEIO, "Global administrator access is restricted to: 'backupFolders', 'backups', and 'Users'.", filename)
+
+
 class NTACLError(PathError):
 
     def __init__(self, filename):

--- a/cterasdk/lib/session/core.py
+++ b/cterasdk/lib/session/core.py
@@ -18,6 +18,7 @@ class Role(Object):
     """User Role"""
 
     def __init__(self, name, authorizations):
+        super().__init__()
         self.name = name
         if authorizations:
             self.access_end_user_folders = authorizations.access_end_user_folders

--- a/cterasdk/lib/session/core.py
+++ b/cterasdk/lib/session/core.py
@@ -1,15 +1,26 @@
 import logging
 from .base import BaseSession, BaseUser
 from .types import Product
+from ...common import Object
+from ...core.enum import Administrators
 
 
 class PortalUser(BaseUser):
     """Local User"""
 
-    def __init__(self, name, domain, tenant, role):
+    def __init__(self, name, domain, tenant, role, authorizations):
         super().__init__(name, domain)
         self.tenant = tenant
-        self.role = role
+        self.role = Role(role, authorizations)
+
+
+class Role(Object):
+    """User Role"""
+
+    def __init__(self, name, authorizations):
+        self.name = name
+        if authorizations:
+            self.access_end_user_folders = authorizations.access_end_user_folders
 
 
 class Session(BaseSession):
@@ -22,25 +33,28 @@ class Session(BaseSession):
 
     def _start_session(self, session):
         logging.getLogger('cterasdk.core').debug('Starting Session.')
-        current_session = session.api.get('/currentSession')
+        user_session = session.api.get('/currentSession')
         current_tenant = session.api.get('/currentPortal') or Session.Administration
         software_version = session.api.get('/version')
-        self._update_session(current_session, current_tenant, software_version)
+        authorizations = session.roles.get(user_session.role) if user_session.role in Administrators else None
+        self._update_session(user_session, current_tenant, software_version, authorizations)
 
     async def _async_start_session(self, session):
         logging.getLogger('cterasdk.core').debug('Starting Session.')
-        current_session = session.v1.api.get('/currentSession')
+        user_session = await session.v1.api.get('/currentSession')
         current_tenant = session.v1.api.get('/currentPortal')
         software_version = session.v1.api.get('/version')
-        self._update_session(await current_session, await current_tenant or Session.Administration, await software_version)
+        authorizations = await session.roles.get(user_session.role) if user_session.role in Administrators else None
+        self._update_session(user_session, await current_tenant or Session.Administration, await software_version, authorizations)
 
-    def _update_session(self, current_session, current_tenant, software_version):
+    def _update_session(self, user_session, current_tenant, software_version, authorizations):
         self._update_account(
             PortalUser(
-                current_session.username,
-                current_session.domain,
+                user_session.username,
+                user_session.domain,
                 current_tenant,
-                current_session.role
+                user_session.role,
+                authorizations
             )
         )
         self._update_software_version(software_version)

--- a/cterasdk/objects/asynchronous/core.py
+++ b/cterasdk/objects/asynchronous/core.py
@@ -4,7 +4,7 @@ from ..endpoints import EndpointBuilder
 from ...clients import clients
 from .. import authenticators
 from ...lib.session.core import Session
-from ...asynchronous.core import files, login, cloudfs, notifications, portals, settings, tasks, users
+from ...asynchronous.core import files, login, cloudfs, notifications, portals, roles, settings, tasks, users
 
 
 class Clients:
@@ -61,6 +61,7 @@ class AsyncPortal(AsyncManagement):
         self.cloudfs = cloudfs.CloudFS(self)
         self.files = files.CloudDrive(self)
         self.notifications = notifications.Notifications(self)
+        self.roles = roles.Roles(self)
         self.settings = settings.Settings(self)
         self.tasks = tasks.Tasks(self)
         self.users = users.Users(self)

--- a/docs/source/UserGuides/Miscellaneous/Changelog.rst
+++ b/docs/source/UserGuides/Miscellaneous/Changelog.rst
@@ -9,7 +9,7 @@ Improvements
 
 * Capture the logged-on user's permission to access user folders
 * Add ability to:
-  
+
   - Compute paths based on slices
   - Compute paths relative to another path
   - Verify whether a path is relative to another path

--- a/docs/source/UserGuides/Miscellaneous/Changelog.rst
+++ b/docs/source/UserGuides/Miscellaneous/Changelog.rst
@@ -6,11 +6,22 @@ Changelog
 
 Improvements
 ^^^^^^^^^^^^
-* Added ``strict_permission`` support to core file operations (mkdir/makedirs/upload/copy/move/rename/delete)
-* Refined strict permission handling to avoid false permission errors on successful operations
-* Improved strict permission detection for background tasks using rc/msg/error_type tuples
-* Adjusted recursive directory creation to skip portal root segments
-* Treat completed-with-warnings background tasks as successful results
+
+* Capture the logged-on user's permission to access user folders
+* Add ability to:
+  
+  - Compute paths based on slices
+  - Compute paths relative to another path
+  - Verify whether a path is relative to another path
+
+* Add a function to verify and raise an error on user access before executing a remote file system command
+* Support validating user permissions for the following commands:
+
+  ``handle``, ``handle_many``, ``download``, ``download_many``, ``mkdir``,
+  ``makedirs``, ``listdir``, ``walk``, ``properties``, ``exists``,
+  ``versions``, ``permalink``, ``copy``, ``move``, ``delete``,
+  ``upload``, ``upload_file``
+
 * Support "upload only" permission when sharing public links
 * Migrate SDK configuration from YAML file to Python module
 * Support bearer token authentication

--- a/docs/source/UserGuides/Portal/Administration.rst
+++ b/docs/source/UserGuides/Portal/Administration.rst
@@ -1542,12 +1542,12 @@ To manage zones, you must be a Read Write Administrator
    """
    Add the following cloud folders to zone: 'ZN-001'
 
-   1) 'Accounting' folder owned by 'Bruce'
-   2) 'HR' folder owned by 'Diana'
+   1) 'Accounting' folder owned by 'Alice'
+   2) 'HR' folder owned by 'Bob'
    """
 
-   accounting = core_types.CloudFSFolderFindingHelper('Accounting', 'Bruce')
-   hr = core_types.CloudFSFolderFindingHelper('HR', 'Diana')
+   accounting = core_types.CloudFSFolderFindingHelper('Accounting', core_types.UserAccount('Alice'))
+   hr = core_types.CloudFSFolderFindingHelper('HR', core_types.UserAccount('Bob'))
 
    admin.cloudfs.zones.add_folders('ZN-001', [accounting, hr])
 

--- a/tests/ut/core/user/base_user.py
+++ b/tests/ut/core/user/base_user.py
@@ -13,6 +13,7 @@ class BaseCoreServicesTest(base.BaseTest):
         self._services = ServicesPortal("")
         self._base = '/ServicesPortal/webdav'
         self._task_reference = 'servers/MainDB/bgTasks/918908'
+        self.patch_call('cterasdk.cio.core.commands.raise_or_suppress_access_error')
 
     @staticmethod
     def encode_path(path):

--- a/tests/ut/core/user/test_browser.py
+++ b/tests/ut/core/user/test_browser.py
@@ -18,6 +18,7 @@ class TestSynchronousFileBrowser(base_admin.BaseCoreTest):
         self.directory_path = 'a/b c/d'
         self.filename = 'Document.txt'
         self.new_filename = 'Summary.txt'
+        self.patch_call('cterasdk.cio.core.commands.raise_or_suppress_access_error')
 
     def test_versions(self):
         directory = 'Users/John Smith/My Files'

--- a/tests/ut/core/user/test_mkdir.py
+++ b/tests/ut/core/user/test_mkdir.py
@@ -24,27 +24,3 @@ class BaseCoreServicesFilesMkdir(base_user.BaseCoreServicesTest):
         })
         actual_param = self._services.api.execute.call_args[0][2]
         self._assert_equal_objects(actual_param, expected_param)
-
-    def test_mkdir_strict_permission_success(self):
-        self._init_services(execute_response=None)
-        ret = self._services.files.mkdir(self._directory, strict_permission=True)
-        self.assertEqual(ret, self._directory)
-
-    def test_mkdir_strict_permission_denied(self):
-        execute_response = Object(rc=0)
-        self._init_services(execute_response=execute_response)
-        with self.assertRaises(exceptions.io.core.PrivilegeError):
-            self._services.files.mkdir(self._directory, strict_permission=True)
-
-    def test_mkdir_strict_permission_denied_message(self):
-        execute_response = Object(msg='access denied')
-        self._init_services(execute_response=execute_response)
-        with self.assertRaises(exceptions.io.core.PrivilegeError):
-            self._services.files.mkdir(self._directory, strict_permission=True)
-
-    def test_makedirs_strict_permission_root_path(self):
-        rooted_directories = 'Team Portal/Engineering/Documents'
-        self._init_services(execute_response=None)
-        ret = self._services.files.makedirs(rooted_directories, strict_permission=True)
-        self.assertEqual(self._services.api.execute.call_count, len(rooted_directories.split('/')))
-        self.assertEqual(ret, rooted_directories)

--- a/tests/ut/core/user/test_mkdir.py
+++ b/tests/ut/core/user/test_mkdir.py
@@ -36,6 +36,12 @@ class BaseCoreServicesFilesMkdir(base_user.BaseCoreServicesTest):
         with self.assertRaises(exceptions.io.core.PrivilegeError):
             self._services.files.mkdir(self._directory, strict_permission=True)
 
+    def test_mkdir_strict_permission_denied_message(self):
+        execute_response = Object(msg='access denied')
+        self._init_services(execute_response=execute_response)
+        with self.assertRaises(exceptions.io.core.PrivilegeError):
+            self._services.files.mkdir(self._directory, strict_permission=True)
+
     def test_makedirs_strict_permission_root_path(self):
         rooted_directories = 'Team Portal/Engineering/Documents'
         self._init_services(execute_response=None)

--- a/tests/ut/core/user/test_mkdir.py
+++ b/tests/ut/core/user/test_mkdir.py
@@ -35,3 +35,10 @@ class BaseCoreServicesFilesMkdir(base_user.BaseCoreServicesTest):
         self._init_services(execute_response=execute_response)
         with self.assertRaises(exceptions.io.core.PrivilegeError):
             self._services.files.mkdir(self._directory, strict_permission=True)
+
+    def test_makedirs_strict_permission_root_path(self):
+        rooted_directories = 'Team Portal/Engineering/Documents'
+        self._init_services(execute_response=None)
+        ret = self._services.files.makedirs(rooted_directories, strict_permission=True)
+        self.assertEqual(self._services.api.execute.call_count, len(rooted_directories.split('/')))
+        self.assertEqual(ret, rooted_directories)

--- a/tests/ut/core/user/test_mkdir.py
+++ b/tests/ut/core/user/test_mkdir.py
@@ -1,9 +1,5 @@
 from unittest import mock
 import munch
-
-from cterasdk.common import Object
-from cterasdk import exceptions
-
 from tests.ut.core.user import base_user
 
 

--- a/tests/ut/core/user/test_move.py
+++ b/tests/ut/core/user/test_move.py
@@ -32,6 +32,14 @@ class BaseCoreServicesFilesMove(base_user.BaseCoreServicesTest):
             self._services.files.move(self._source, destination=self._dest, strict_permission=True)
         self._services.tasks.wait.assert_called_once_with(self._task_reference)
 
+    def test_move_strict_permission_denied_error_type(self):
+        task = Object(error_type='permissiondenied')
+        self._services.tasks.wait = mock.MagicMock(return_value=task)
+        self._init_services(execute_response=self._task_reference)
+        with self.assertRaises(exceptions.io.core.PrivilegeError):
+            self._services.files.move(self._source, destination=self._dest, strict_permission=True)
+        self._services.tasks.wait.assert_called_once_with(self._task_reference)
+
     def test_move_completed_with_warnings_raises_move_error(self):
         task = mock.MagicMock()
         task.completed = False

--- a/tests/ut/core/user/test_move.py
+++ b/tests/ut/core/user/test_move.py
@@ -1,8 +1,5 @@
 from unittest import mock
-
-from cterasdk.common import Object
 from cterasdk import exceptions
-
 from tests.ut.core.user import base_user
 
 

--- a/tests/ut/core/user/test_move.py
+++ b/tests/ut/core/user/test_move.py
@@ -24,22 +24,6 @@ class BaseCoreServicesFilesMove(base_user.BaseCoreServicesTest):
         self._assert_equal_objects(actual_param, expected_param)
         self.assertEqual(ret.ref, execute_response)
 
-    def test_move_strict_permission_denied(self):
-        task = Object(msg='permission denied')
-        self._services.tasks.wait = mock.MagicMock(return_value=task)
-        self._init_services(execute_response=self._task_reference)
-        with self.assertRaises(exceptions.io.core.PrivilegeError):
-            self._services.files.move(self._source, destination=self._dest, strict_permission=True)
-        self._services.tasks.wait.assert_called_once_with(self._task_reference)
-
-    def test_move_strict_permission_denied_error_type(self):
-        task = Object(error_type='permissiondenied')
-        self._services.tasks.wait = mock.MagicMock(return_value=task)
-        self._init_services(execute_response=self._task_reference)
-        with self.assertRaises(exceptions.io.core.PrivilegeError):
-            self._services.files.move(self._source, destination=self._dest, strict_permission=True)
-        self._services.tasks.wait.assert_called_once_with(self._task_reference)
-
     def test_move_completed_with_warnings_raises_move_error(self):
         task = mock.MagicMock()
         task.completed = False
@@ -52,7 +36,7 @@ class BaseCoreServicesFilesMove(base_user.BaseCoreServicesTest):
         self._services.tasks.wait = mock.MagicMock(return_value=task)
         self._init_services(execute_response=self._task_reference)
         with self.assertRaises(exceptions.io.core.MoveError):
-            self._services.files.move(self._source, destination=self._dest, strict_permission=True)
+            self._services.files.move(self._source, destination=self._dest)
         self._services.tasks.wait.assert_called_once_with(self._task_reference)
 
     def _create_move_resource_param(self):

--- a/tests/ut/core/user/test_move.py
+++ b/tests/ut/core/user/test_move.py
@@ -32,6 +32,21 @@ class BaseCoreServicesFilesMove(base_user.BaseCoreServicesTest):
             self._services.files.move(self._source, destination=self._dest, strict_permission=True)
         self._services.tasks.wait.assert_called_once_with(self._task_reference)
 
+    def test_move_completed_with_warnings_raises_move_error(self):
+        task = mock.MagicMock()
+        task.completed = False
+        task.completed_with_warnings = True
+        task.failed = False
+        task.cursor = None
+        task.error_type = None
+        task.unknown_object.return_value = True
+        task.progress_str = None
+        self._services.tasks.wait = mock.MagicMock(return_value=task)
+        self._init_services(execute_response=self._task_reference)
+        with self.assertRaises(exceptions.io.core.MoveError):
+            self._services.files.move(self._source, destination=self._dest, strict_permission=True)
+        self._services.tasks.wait.assert_called_once_with(self._task_reference)
+
     def _create_move_resource_param(self):
         destinations = [base_user.BaseCoreServicesTest.encode_path(self._dest + '/' + self._filename)]
         return self._create_action_resource_param([base_user.BaseCoreServicesTest.encode_path(self._source)], destinations)


### PR DESCRIPTION
### Description

This pull request focuses on adding unit tests for strict permission errors in file and directory operations. It also simplifies the permission error handling logic in the following ways:

- Adds tests for handling `completed_with_warnings` in file operations.
- Removes the strict permission argument from directory creation commands in `_parents_generator`.
- Adds a test for strict permission directory creation at root paths.

