### PR TITLE
SDK-365 Fix infinite retry loop in ResolverCommand when error is not a file conflict

### DIFF
--- a/cterasdk/cio/core/commands.py
+++ b/cterasdk/cio/core/commands.py
@@ -1097,7 +1097,7 @@ class ResolverCommand(TaskCommand):
         try:
             return super().execute()
         except (exceptions.io.core.CopyError, exceptions.io.core.MoveError, exceptions.io.core.RenameError) as e:
-            if self.resolver:
+            if self.resolver and isinstance(e.__cause__, exceptions.io.core.FileConflictError):
                 return self._try_with_resolver(e.cursor)
             return self._handle_exception(e)
 
@@ -1105,7 +1105,7 @@ class ResolverCommand(TaskCommand):
         try:
             return await super().a_execute()
         except (exceptions.io.core.CopyError, exceptions.io.core.MoveError, exceptions.io.core.RenameError) as e:
-            if self.resolver:
+            if self.resolver and isinstance(e.__cause__, exceptions.io.core.FileConflictError):
                 return await self._a_try_with_resolver(e.cursor)
             return self._handle_exception(e)
 


### PR DESCRIPTION
## Summary

- Fix infinite retry loop in `ResolverCommand.execute()` and `a_execute()` when the error is not a file conflict
- Previously, any `CopyError`/`MoveError`/`RenameError` with a resolver present would trigger a retry, causing an infinite loop for PermissionDenied and other non-conflict errors
- Now only retries when `e.__cause__` is `FileConflictError`

## Root Cause

When a ReadOnlyAdmin copies/moves between users cloud folders with a conflict resolver:
1. Portal correctly rejects with PermissionDeniedException
2. SDK raises CopyError (without FileConflictError cause)
3. `a_execute()` catches CopyError, sees resolver is set, retries
4. Infinite loop (~1 request/second until MCP stream timeout at 5 minutes)

## Test plan

- [x] Verified on Portal VM: RO Admin copy with conflict_resolution=rename now returns error in ~1 second (was hanging indefinitely)
- [x] Normal copy with conflict resolver still works correctly
- [x] Normal copy/move without resolver unaffected

Fixes: https://cteranet.atlassian.net/browse/SDK-365
Related: https://cteranet.atlassian.net/browse/PIM-7443