### PR TITLE
PIM-7684: Recover raises RecoverError when files_processed is 0

### DIFF
--- a/cterasdk/asynchronous/core/files/browser.py
+++ b/cterasdk/asynchronous/core/files/browser.py
@@ -11,7 +11,7 @@ from . import io
 class FileBrowser(BaseCommand):
     """Async File Browser API."""
 
-    async def handle(self, path, objects=None):
+    async def handle(self, path, objects):
         """
         Get a file handle.
 

--- a/cterasdk/asynchronous/core/files/browser.py
+++ b/cterasdk/asynchronous/core/files/browser.py
@@ -11,7 +11,7 @@ from . import io
 class FileBrowser(BaseCommand):
     """Async File Browser API."""
 
-    async def handle(self, path, objects):
+    async def handle(self, path, objects=None):
         """
         Get a file handle.
 

--- a/cterasdk/cio/core/commands.py
+++ b/cterasdk/cio/core/commands.py
@@ -1043,6 +1043,11 @@ class Recover(MultiResourceCommand):
     def _progress_str(self):
         return 'Recovering'
 
+    def _task_complete(self, task):
+        if getattr(task, 'files_processed', None) == 0:
+            return self._task_error(task)
+        return super()._task_complete(task)
+
     def _task_error(self, task):
         cursor = task.cursor
         raise exceptions.io.core.RecoverError(self.paths, cursor)


### PR DESCRIPTION
## Summary
Override `_task_complete` in the `Recover` command class to raise `RecoverError` when `files_processed == 0`.

## Why is this needed?

The SDK's `_handle_response` dispatches based on task status:
- `failed` → `_task_error` → raises `RecoverError` ✔
- `completed_with_warnings` → `_task_error` → raises `RecoverError` ✔
- `completed` → `_task_complete` → returns success (list of paths) — **no error check**

The problem: when recovering files that no longer exist in trash, the Portal can return the task with status `completed` but `files_processed = 0`. Without this check, the SDK reports success to the caller even though nothing was actually recovered.

This means callers (like the MCP) would tell the user "Recovered: [path]" when in reality the file was not recovered.

## What does the fix do?

Before delegating to the parent `_task_complete` (which returns the path list as success), we check if `files_processed == 0`. If so, we route to `_task_error` which raises `RecoverError` — consistent with how `failed` and `completed_with_warnings` are handled.

## Test plan
- [x] All 696 SDK unit tests pass
- [x] Deployed to Portal VM and verified:
  - Recover of deleted file → success
  - Recover of non-existent file → `RecoverError` raised