### PR TITLE
SDK-373 Skip Direct IO decrypt and decompress when the portal reports a plaintext native object

### DIFF
--- a/cterasdk/direct/client.py
+++ b/cterasdk/direct/client.py
@@ -96,7 +96,8 @@ class DirectIO:
             Asynchronous Executable of Chunk Retrieval Tasks.
             """
             return await process_chunks(self._client, file_id, chunks, metadata.encryption_key,
-                                        asyncio.Semaphore(max_workers) if max_workers else None)
+                                        asyncio.Semaphore(max_workers) if max_workers else None,
+                                        encrypted=metadata.encrypted, compressed=metadata.compressed)
 
         return execute
 

--- a/cterasdk/direct/client.py
+++ b/cterasdk/direct/client.py
@@ -73,6 +73,7 @@ class DirectIO:
         :returns: Streamer object.
         :rtype: cterasdk.direct.stream.Streamer
         """
+        byte_range = byte_range if byte_range is not None else ByteRange.default()
         executor = self.executor(await self._chunks(file_id), byte_range=byte_range, max_workers=max_workers)
         return Streamer(executor, byte_range)
 

--- a/cterasdk/direct/client.py
+++ b/cterasdk/direct/client.py
@@ -96,9 +96,10 @@ class DirectIO:
             """
             Asynchronous Executable of Chunk Retrieval Tasks.
             """
-            return await process_chunks(self._client, file_id, chunks, metadata.encryption_key,
-                                        asyncio.Semaphore(max_workers) if max_workers else None,
-                                        encrypted=metadata.encrypted, compressed=metadata.compressed)
+            return await process_chunks(self._client, file_id, chunks,
+                                        metadata.encryption_key,
+                                        metadata.compression_library,
+                                        asyncio.Semaphore(max_workers) if max_workers else None)
 
         return execute
 

--- a/cterasdk/direct/lib.py
+++ b/cterasdk/direct/lib.py
@@ -89,6 +89,12 @@ async def decrypt_object(file_id, encrypted_object, encryption_key, chunk):
         raise DecryptBlockError(file_id, chunk)
 
 
+def _validate_block_length(file_id, data, chunk):
+    if chunk.length != len(data):
+        logger.error('Expected block length does not match downloaded block length.')
+        raise BlockValidationException(file_id, chunk)
+
+
 async def decompress_object(file_id, compressed_object, chunk):
     """
     Decompress Object.
@@ -100,16 +106,16 @@ async def decompress_object(file_id, compressed_object, chunk):
     """
     try:
         decompressed_object = decompress(compressed_object)
-        if chunk.length != len(decompressed_object):
-            logger.error('Expected block length does not match decrypted and decompressed block length.')
-            raise BlockValidationException(file_id, chunk)
+        _validate_block_length(file_id, decompressed_object, chunk)
         return decompressed_object
+    except BlockValidationException:
+        raise
     except DirectIOError:
         logger.error('Failed to decompress block.')
         raise DecompressBlockError(file_id, chunk)
 
 
-async def process_chunk(client, file_id, chunk, encryption_key, semaphore):
+async def process_chunk(client, file_id, chunk, encryption_key, semaphore, encrypted=True, compressed=True):
     """
     Process a Chunk.
 
@@ -118,6 +124,8 @@ async def process_chunk(client, file_id, chunk, encryption_key, semaphore):
     :param cterasdk.direct.types.Chunk chunk: Chunk.
     :param str encryption_key: Encryption key.
     :param asyncio.Semaphore semaphore: Semaphore.
+    :param bool,optional encrypted: Decrypt the downloaded object. Defaults to ``True``.
+    :param bool,optional compressed: Decompress the downloaded object. Defaults to ``True``.
 
     :returns: Block
     :rtype: cterasdk.direct.types.Block
@@ -130,10 +138,14 @@ async def process_chunk(client, file_id, chunk, encryption_key, semaphore):
         if file_id:
             message = message + f" for file ID {file_id}"
         logger.debug(message)
-        encrypted_object = await get_object(client, file_id, chunk)
-        decrypted_object = await decrypt_object(file_id, encrypted_object, encryption_key, chunk)
-        decompressed_object = await decompress_object(file_id, decrypted_object, chunk)
-        return Block(file_id, chunk.number, chunk.offset, decompressed_object, chunk.length)
+        downloaded_object = await get_object(client, file_id, chunk)
+        if encrypted:
+            downloaded_object = await decrypt_object(file_id, downloaded_object, encryption_key, chunk)
+        if compressed:
+            downloaded_object = await decompress_object(file_id, downloaded_object, chunk)
+        else:
+            _validate_block_length(file_id, downloaded_object, chunk)
+        return Block(file_id, chunk.number, chunk.offset, downloaded_object, chunk.length)
 
     if semaphore is not None:
         async with semaphore:
@@ -141,7 +153,7 @@ async def process_chunk(client, file_id, chunk, encryption_key, semaphore):
     return await process(client, chunk, encryption_key)
 
 
-async def process_chunks(client, file_id, chunks, encryption_key, semaphore=None):
+async def process_chunks(client, file_id, chunks, encryption_key, semaphore=None, encrypted=True, compressed=True):
     """
     Process Chunks Asynchronously.
 
@@ -150,6 +162,8 @@ async def process_chunks(client, file_id, chunks, encryption_key, semaphore=None
     :param list[cterasdk.direct.types.Chunk] chunks: Chunk.
     :param str encryption_key: Encryption key.
     :param asyncio.Semaphore,optional semaphore: Semaphore.
+    :param bool,optional encrypted: Decrypt downloaded objects. Defaults to ``True``.
+    :param bool,optional compressed: Decompress downloaded objects. Defaults to ``True``.
     :returns: List of futures.
     :rtype: list[asyncio.Task]
     """
@@ -161,7 +175,8 @@ async def process_chunks(client, file_id, chunks, encryption_key, semaphore=None
     logger.debug(' '.join(message))
     futures = []
     for chunk in chunks:
-        futures.append(asyncio.create_task(process_chunk(client, file_id, chunk, encryption_key, semaphore)))
+        futures.append(asyncio.create_task(process_chunk(
+            client, file_id, chunk, encryption_key, semaphore, encrypted=encrypted, compressed=compressed)))
     return futures
 
 

--- a/cterasdk/direct/lib.py
+++ b/cterasdk/direct/lib.py
@@ -83,39 +83,34 @@ async def decrypt_object(file_id, encrypted_object, encryption_key, chunk):
     :rtype: bytes
     """
     try:
-        return decrypt_block(encrypted_object, encryption_key)
+        return decrypt_block(encrypted_object, encryption_key) if encryption_key is not None else encrypted_object
     except DirectIOError:
         logger.error('Failed to decrypt block.')
         raise DecryptBlockError(file_id, chunk)
 
 
-def _validate_block_length(file_id, data, chunk):
-    if chunk.length != len(data):
-        logger.error('Expected block length does not match downloaded block length.')
-        raise BlockValidationException(file_id, chunk)
-
-
-async def decompress_object(file_id, compressed_object, chunk):
+async def decompress_object(file_id, compressed_object, compression_library, chunk):
     """
     Decompress Object.
 
     :param bytes compressed_object: Compressed object.
+    :param str compression_library: Compression library.
     :param cterasdk.direct.types.Chunk chunk: Chunk.
     :returns: Decompressed Object.
     :rtype: bytes
     """
     try:
-        decompressed_object = decompress(compressed_object)
-        _validate_block_length(file_id, decompressed_object, chunk)
+        decompressed_object = decompress(compressed_object) if compression_library is not None else compressed_object
+        if chunk.length != len(decompressed_object):
+            logger.error('Expected block length does not match decrypted and decompressed block length.')
+            raise BlockValidationException(file_id, chunk)
         return decompressed_object
-    except BlockValidationException:
-        raise
-    except DirectIOError:
+    except DirectIOError as e:
         logger.error('Failed to decompress block.')
-        raise DecompressBlockError(file_id, chunk)
+        raise DecompressBlockError(file_id, chunk) from e
 
 
-async def process_chunk(client, file_id, chunk, encryption_key, semaphore, encrypted=True, compressed=True):
+async def process_chunk(client, file_id, chunk, encryption_key, compression_library, semaphore):
     """
     Process a Chunk.
 
@@ -123,6 +118,7 @@ async def process_chunk(client, file_id, chunk, encryption_key, semaphore, encry
     :param int file_id: File ID.
     :param cterasdk.direct.types.Chunk chunk: Chunk.
     :param str encryption_key: Encryption key.
+    :param str compression_library: Compression library.
     :param asyncio.Semaphore semaphore: Semaphore.
     :param bool,optional encrypted: Decrypt the downloaded object. Defaults to ``True``.
     :param bool,optional compressed: Decompress the downloaded object. Defaults to ``True``.
@@ -138,14 +134,10 @@ async def process_chunk(client, file_id, chunk, encryption_key, semaphore, encry
         if file_id:
             message = message + f" for file ID {file_id}"
         logger.debug(message)
-        downloaded_object = await get_object(client, file_id, chunk)
-        if encrypted:
-            downloaded_object = await decrypt_object(file_id, downloaded_object, encryption_key, chunk)
-        if compressed:
-            downloaded_object = await decompress_object(file_id, downloaded_object, chunk)
-        else:
-            _validate_block_length(file_id, downloaded_object, chunk)
-        return Block(file_id, chunk.number, chunk.offset, downloaded_object, chunk.length)
+        encrypted_object = await get_object(client, file_id, chunk)
+        decrypted_object = await decrypt_object(file_id, encrypted_object, encryption_key, chunk)
+        decompressed_object = await decompress_object(file_id, decrypted_object, compression_library, chunk)
+        return Block(file_id, chunk.number, chunk.offset, decompressed_object, chunk.length)
 
     if semaphore is not None:
         async with semaphore:
@@ -153,7 +145,7 @@ async def process_chunk(client, file_id, chunk, encryption_key, semaphore, encry
     return await process(client, chunk, encryption_key)
 
 
-async def process_chunks(client, file_id, chunks, encryption_key, semaphore=None, encrypted=True, compressed=True):
+async def process_chunks(client, file_id, chunks, encryption_key, compression_library, semaphore=None):
     """
     Process Chunks Asynchronously.
 
@@ -161,9 +153,8 @@ async def process_chunks(client, file_id, chunks, encryption_key, semaphore=None
     :param int file_id: File ID.
     :param list[cterasdk.direct.types.Chunk] chunks: Chunk.
     :param str encryption_key: Encryption key.
+    :param str compression_library: Compression library.
     :param asyncio.Semaphore,optional semaphore: Semaphore.
-    :param bool,optional encrypted: Decrypt downloaded objects. Defaults to ``True``.
-    :param bool,optional compressed: Decompress downloaded objects. Defaults to ``True``.
     :returns: List of futures.
     :rtype: list[asyncio.Task]
     """
@@ -176,7 +167,7 @@ async def process_chunks(client, file_id, chunks, encryption_key, semaphore=None
     futures = []
     for chunk in chunks:
         futures.append(asyncio.create_task(process_chunk(
-            client, file_id, chunk, encryption_key, semaphore, encrypted=encrypted, compressed=compressed)))
+            client, file_id, chunk, encryption_key, compression_library, semaphore)))
     return futures
 
 

--- a/cterasdk/exceptions/direct.py
+++ b/cterasdk/exceptions/direct.py
@@ -116,7 +116,7 @@ class DecompressBlockError(BlockError):
 class BlockValidationException(BlockError):
 
     def __init__(self, file_id, chunk):
-        super().__init__(errno.EIO, 'Expected block length does not match decrypted and decompressed block length', file_id, chunk)
+        super().__init__(errno.EIO, 'Expected block length does not match downloaded block length', file_id, chunk)
 
 
 class BlockInfo:

--- a/docs/source/UserGuides/Miscellaneous/Changelog.rst
+++ b/docs/source/UserGuides/Miscellaneous/Changelog.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+2.20.46
+-------
+
+Improvements
+^^^^^^^^^^^^
+
+* Support CTERA Direct I/O download for files stored in Fusion Direct cloudfolders
+
+Related issues and pull requests on GitHub: `#369 <https://github.com/ctera/ctera-python-sdk/pull/369>`_
+
 2.20.45
 -------
 


### PR DESCRIPTION
Fusion Direct Direct IO responses are unencrypted and uncompressed, but process_chunk always decrypted and decompressed, which broke native object downloads. The client now honors encrypt_info.data_encrypted and compression_type and returns the downloaded bytes as-is when both are off. Classic block downloads keep the existing decrypt/decompress path.